### PR TITLE
hotfix: remove non-existent OpenGraph image reference

### DIFF
--- a/src/server/metadata-helpers.ts
+++ b/src/server/metadata-helpers.ts
@@ -587,17 +587,6 @@ export function generateRaidMetadata(raidData: any, raidId: number) {
     type: "website" as const,
     url: `/raids/${raidId}`,
     siteName: "Temple Raid Attendance",
-    images:
-      raidData.totalKills > 0
-        ? [
-            {
-              url: `/api/og/raid/${raidId}`,
-              width: 1200,
-              height: 630,
-              alt: `${raidData.name} raid completion`,
-            },
-          ]
-        : undefined,
   };
 
   // Build structured data for SEO


### PR DESCRIPTION
## Problem
Social media platforms were experiencing unfurling issues when trying to fetch OpenGraph images for raid pages. The metadata was referencing a non-existent endpoint .

## Solution
- Removed the  property from the OpenGraph metadata in  function
- This prevents social media platforms from attempting to fetch non-existent images
- OpenGraph metadata still works properly for title, description, and other properties

## Impact
- Fixes unfurling issues for raid page links shared on social media
- No functional impact on the application
- Character metadata was already clean (no image references)

## Files Changed
- : Removed images property from raid OpenGraph data