### PR TITLE
Fix timezone handling in raid metadata to prevent day shifts

### DIFF
--- a/src/server/metadata-helpers.ts
+++ b/src/server/metadata-helpers.ts
@@ -470,13 +470,12 @@ function generateCharacterStoryDescription(characterData: any): string {
 function generateRaidStoryDescription(raidData: any): string {
   if (!raidData) return "Raid details unavailable";
 
-  // Format date in ET (assuming UTC input)
-  const raidDate = new Date(raidData.date + "T00:00:00Z"); // Ensure UTC
+  // Treat the date as a local date without timezone conversion to avoid day shifts
+  const raidDate = new Date(raidData.date + "T00:00:00");
   const friendlyDate = raidDate.toLocaleDateString("en-US", {
     month: "long",
     day: "numeric",
     year: "numeric",
-    timeZone: "America/New_York", // Proper ET timezone handling
   });
 
   // Get raid time from logs


### PR DESCRIPTION
## Problem
Raid metadata was displaying dates one day earlier than expected (e.g., Sept 17 raids showing as Sept 16).

## Root Cause
Inconsistent timezone handling between character and raid metadata:
- **Character metadata**: Used local date parsing ()
- **Raid metadata**: Used UTC date parsing () with timezone conversion

The UTC approach caused dates to shift backward when converted to ET timezone.

## Solution
- Aligned raid metadata date handling with character metadata approach
- Changed from UTC parsing to local date parsing
- Removed timezone conversion that was causing day shifts
- Updated comments to reflect the correct approach

## Testing
- Raid dates now display correctly without day shifts
- Maintains consistency with character metadata date handling
- No breaking changes to existing functionality

Fixes timezone-related date display issues in raid metadata.