### PR TITLE
feat: Add role-based access control to quick launcher

### DIFF
--- a/src/components/ui/global-quick-launcher.tsx
+++ b/src/components/ui/global-quick-launcher.tsx
@@ -2,8 +2,18 @@
 
 import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { Calendar, Search, Home, Users, BookOpen } from "lucide-react";
+import {
+  Calendar,
+  Search,
+  Home,
+  Users,
+  BookOpen,
+  FilePlus,
+  ListRestart,
+  ShieldCheck,
+} from "lucide-react";
 import { useDebounce } from "use-debounce";
+import { useSession } from "next-auth/react";
 
 import { useGlobalQuickLauncher } from "~/contexts/global-quick-launcher-context";
 import { Dialog, DialogContent, DialogTitle } from "~/components/ui/dialog";
@@ -14,6 +24,7 @@ import { formatRaidDate, formatRaidCompletion } from "~/lib/raid-formatting";
 export function GlobalQuickLauncher() {
   const { open, setOpen } = useGlobalQuickLauncher();
   const router = useRouter();
+  const { data: session } = useSession();
   const [query, setQuery] = useState("");
   const [debouncedQuery] = useDebounce(query, 300);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -67,6 +78,44 @@ export function GlobalQuickLauncher() {
         icon: BookOpen,
         type: "page" as const,
       },
+      // Raid Manager pages
+      ...(session?.user?.isRaidManager
+        ? [
+            {
+              name: "Create new raid",
+              path: "/raids/new",
+              icon: FilePlus,
+              type: "page" as const,
+              role: "Raid Manager",
+            },
+            {
+              name: "Manage mains v. alts",
+              path: "/raid-manager/characters",
+              icon: Users,
+              type: "page" as const,
+              role: "Raid Manager",
+            },
+            {
+              name: "Refresh WCL log",
+              path: "/raid-manager/log-refresh",
+              icon: ListRestart,
+              type: "page" as const,
+              role: "Raid Manager",
+            },
+          ]
+        : []),
+      // Admin pages
+      ...(session?.user?.isAdmin
+        ? [
+            {
+              name: "User permissions",
+              path: "/admin/user-management",
+              icon: ShieldCheck,
+              type: "page" as const,
+              role: "Admin",
+            },
+          ]
+        : []),
     ];
 
     const matchedStaticPages = staticPages.filter(
@@ -177,6 +226,48 @@ export function GlobalQuickLauncher() {
                     type: "page" as const,
                     sortDate: Number.MAX_SAFE_INTEGER - 3,
                   },
+                  // Raid Manager pages
+                  ...(session?.user?.isRaidManager
+                    ? [
+                        {
+                          name: "Create new raid",
+                          path: "/raids/new",
+                          icon: FilePlus,
+                          type: "page" as const,
+                          sortDate: Number.MAX_SAFE_INTEGER - 4,
+                          role: "Raid Manager",
+                        },
+                        {
+                          name: "Manage mains v. alts",
+                          path: "/raid-manager/characters",
+                          icon: Users,
+                          type: "page" as const,
+                          sortDate: Number.MAX_SAFE_INTEGER - 5,
+                          role: "Raid Manager",
+                        },
+                        {
+                          name: "Refresh WCL log",
+                          path: "/raid-manager/log-refresh",
+                          icon: ListRestart,
+                          type: "page" as const,
+                          sortDate: Number.MAX_SAFE_INTEGER - 6,
+                          role: "Raid Manager",
+                        },
+                      ]
+                    : []),
+                  // Admin pages
+                  ...(session?.user?.isAdmin
+                    ? [
+                        {
+                          name: "User permissions",
+                          path: "/admin/user-management",
+                          icon: ShieldCheck,
+                          type: "page" as const,
+                          sortDate: Number.MAX_SAFE_INTEGER - 7,
+                          role: "Admin",
+                        },
+                      ]
+                    : []),
                 ];
 
                 // Filter static pages based on search query
@@ -276,7 +367,7 @@ export function GlobalQuickLauncher() {
                           </span>
                           <span className="text-xs text-muted-foreground">
                             {result.type === "page"
-                              ? ""
+                              ? result.role || ""
                               : result.type === "raid"
                                 ? `${result.zone} • ${formatRaidDate(result.date)} • ${formatRaidCompletion(result.zone, result.killCount || 0)}`
                                 : `${result.class} • ${result.server}${result.primaryCharacterName ? ` (${result.primaryCharacterName})` : ""}`}


### PR DESCRIPTION
## Overview
This PR adds role-based access control to the global quick launcher, allowing users to see and navigate to Raid Manager and Admin pages based on their permissions.

## Changes Made
- **Added Raid Manager pages** (visible only to users with `isRaidManager` role):
  - Create new raid (`/raids/new`)
  - Manage mains v. alts (`/raid-manager/characters`)
  - Refresh WCL log (`/raid-manager/log-refresh`)

- **Added Admin pages** (visible only to users with `isAdmin` role):
  - User permissions (`/admin/user-management`)

- **Enhanced UX**:
  - Added role descriptions ("Raid Manager", "Admin") to help users understand access requirements
  - Maintains existing functionality for public pages
  - Consistent with sidebar navigation permissions

## Technical Details
- Uses `useSession` hook to access user roles
- Role-based filtering in both keyboard navigation and display logic
- Added appropriate icons for new pages
- No breaking changes to existing functionality

## Testing
- ✅ Public users see only public pages
- ✅ Raid Managers see public + raid manager pages
- ✅ Admins see all pages they have access to
- ✅ Search functionality works with role-based filtering
- ✅ No linter errors

This implementation follows the same pattern used in the sidebar navigation, ensuring consistency across the application.