### PR TITLE
Add raid plan collaboration signals

### DIFF
--- a/drizzle/0019_gifted_nextwave.sql
+++ b/drizzle/0019_gifted_nextwave.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "raid_plan_presence" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"raid_plan_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"client_session_id" varchar(128) NOT NULL,
+	"mode" varchar(16) DEFAULT 'viewing' NOT NULL,
+	"last_seen_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "raid_plan" ADD COLUMN "updated_by" uuid;--> statement-breakpoint
+ALTER TABLE "raid_plan_presence" ADD CONSTRAINT "raid_plan_presence_raid_plan_id_raid_plan_id_fk" FOREIGN KEY ("raid_plan_id") REFERENCES "public"."raid_plan"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "raid_plan_presence" ADD CONSTRAINT "raid_plan_presence_user_id_auth_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."auth_user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "raid_plan_presence__raid_plan_id_idx" ON "raid_plan_presence" USING btree ("raid_plan_id");--> statement-breakpoint
+CREATE INDEX "raid_plan_presence__user_id_idx" ON "raid_plan_presence" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "raid_plan_presence__last_seen_at_idx" ON "raid_plan_presence" USING btree ("last_seen_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "raid_plan_presence__plan_session_idx" ON "raid_plan_presence" USING btree ("raid_plan_id","client_session_id");--> statement-breakpoint
+ALTER TABLE "raid_plan" ADD CONSTRAINT "raid_plan_updated_by_auth_user_id_fk" FOREIGN KEY ("updated_by") REFERENCES "public"."auth_user"("id") ON DELETE set null ON UPDATE no action;

--- a/drizzle/meta/0019_snapshot.json
+++ b/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,2604 @@
+{
+  "id": "b937b444-ece0-47fc-a370-724f33497b1e",
+  "prevId": "4b5365b5-e7ab-4b27-a077-9220fc9a535d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "auth_account_provider_provider_account_id_pk": {
+          "name": "auth_account_provider_provider_account_id_pk",
+          "columns": ["provider", "provider_account_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_spells": {
+      "name": "character_spells",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_spell_id": {
+          "name": "recipe_spell_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_spells_character_id_character_character_id_fk": {
+          "name": "character_spells_character_id_character_character_id_fk",
+          "tableFrom": "character_spells",
+          "tableTo": "character",
+          "columnsFrom": ["character_id"],
+          "columnsTo": ["character_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "character_spells_recipe_spell_id_recipes_recipe_spell_id_fk": {
+          "name": "character_spells_recipe_spell_id_recipes_recipe_spell_id_fk",
+          "tableFrom": "character_spells",
+          "tableTo": "recipes",
+          "columnsFrom": ["recipe_spell_id"],
+          "columnsTo": ["recipe_spell_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "character_spells_created_by_auth_user_id_fk": {
+          "name": "character_spells_created_by_auth_user_id_fk",
+          "tableFrom": "character_spells",
+          "tableTo": "auth_user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "character_spells_updated_by_auth_user_id_fk": {
+          "name": "character_spells_updated_by_auth_user_id_fk",
+          "tableFrom": "character_spells",
+          "tableTo": "auth_user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "character_spells_character_id_recipe_spell_id_pk": {
+          "name": "character_spells_character_id_recipe_spell_id_pk",
+          "columns": ["character_id", "recipe_spell_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character": {
+      "name": "character",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server": {
+          "name": "server",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unknown'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_detail": {
+          "name": "class_detail",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_character_id": {
+          "name": "primary_character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\"character\".\"character_id\" = COALESCE (\"character\".\"primary_character_id\", 0))\n                 OR\n                 \"character\".\"primary_character_id\"\n                 IS\n                 NULL",
+            "type": "stored"
+          }
+        },
+        "is_ignored": {
+          "name": "is_ignored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_via": {
+          "name": "created_via",
+          "type": "created_via",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_via": {
+          "name": "updated_via",
+          "type": "updated_via",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_created_by_auth_user_id_fk": {
+          "name": "character_created_by_auth_user_id_fk",
+          "tableFrom": "character",
+          "tableTo": "auth_user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "character__primary_character_id_fk": {
+          "name": "character__primary_character_id_fk",
+          "tableFrom": "character",
+          "tableTo": "character",
+          "columnsFrom": ["primary_character_id"],
+          "columnsTo": ["character_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_bench_map": {
+      "name": "raid_bench_map",
+      "schema": "",
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_bench_map__raid_id_idx": {
+          "name": "raid_bench_map__raid_id_idx",
+          "columns": [
+            {
+              "expression": "raid_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_bench_map__character_id_idx": {
+          "name": "raid_bench_map__character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_bench_map_raid_id_raid_raid_id_fk": {
+          "name": "raid_bench_map_raid_id_raid_raid_id_fk",
+          "tableFrom": "raid_bench_map",
+          "tableTo": "raid",
+          "columnsFrom": ["raid_id"],
+          "columnsTo": ["raid_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_bench_map_character_id_character_character_id_fk": {
+          "name": "raid_bench_map_character_id_character_character_id_fk",
+          "tableFrom": "raid_bench_map",
+          "tableTo": "character",
+          "columnsFrom": ["character_id"],
+          "columnsTo": ["character_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "raid_bench_map_created_by_auth_user_id_fk": {
+          "name": "raid_bench_map_created_by_auth_user_id_fk",
+          "tableFrom": "raid_bench_map",
+          "tableTo": "auth_user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "raid_bench_map_raid_id_character_id_pk": {
+          "name": "raid_bench_map_raid_id_character_id_pk",
+          "columns": ["raid_id", "character_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_log_attendee_map": {
+      "name": "raid_log_attendee_map",
+      "schema": "",
+      "columns": {
+        "raid_log_id": {
+          "name": "raid_log_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ignored": {
+          "name": "is_ignored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raid_log_attendee_map__raid_log_id_idx": {
+          "name": "raid_log_attendee_map__raid_log_id_idx",
+          "columns": [
+            {
+              "expression": "raid_log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_log_attendee_map__character_id_idx": {
+          "name": "raid_log_attendee_map__character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_log_attendee_map_raid_log_id_raid_log_raid_log_id_fk": {
+          "name": "raid_log_attendee_map_raid_log_id_raid_log_raid_log_id_fk",
+          "tableFrom": "raid_log_attendee_map",
+          "tableTo": "raid_log",
+          "columnsFrom": ["raid_log_id"],
+          "columnsTo": ["raid_log_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_log_attendee_map_character_id_character_character_id_fk": {
+          "name": "raid_log_attendee_map_character_id_character_character_id_fk",
+          "tableFrom": "raid_log_attendee_map",
+          "tableTo": "character",
+          "columnsFrom": ["character_id"],
+          "columnsTo": ["character_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "raid_log_attendee_map_raid_log_id_character_id_pk": {
+          "name": "raid_log_attendee_map_raid_log_id_character_id_pk",
+          "columns": ["raid_log_id", "character_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_log": {
+      "name": "raid_log",
+      "schema": "",
+      "columns": {
+        "raid_log_id": {
+          "name": "raid_log_id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raid_id": {
+          "name": "raid_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone": {
+          "name": "zone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "killCount": {
+          "name": "killCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "cardinality\n          (\"raid_log\".\"kills\")",
+            "type": "stored"
+          }
+        },
+        "start_time_utc": {
+          "name": "start_time_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time_utc": {
+          "name": "end_time_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_log__raid_log_id_idx": {
+          "name": "raid_log__raid_log_id_idx",
+          "columns": [
+            {
+              "expression": "raid_log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_log__discord_message_id_idx": {
+          "name": "raid_log__discord_message_id_idx",
+          "columns": [
+            {
+              "expression": "discord_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_log_raid_id_raid_raid_id_fk": {
+          "name": "raid_log_raid_id_raid_raid_id_fk",
+          "tableFrom": "raid_log",
+          "tableTo": "raid",
+          "columnsFrom": ["raid_id"],
+          "columnsTo": ["raid_id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "raid_log_created_by_auth_user_id_fk": {
+          "name": "raid_log_created_by_auth_user_id_fk",
+          "tableFrom": "raid_log",
+          "tableTo": "auth_user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_character": {
+      "name": "raid_plan_character",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raid_plan_id": {
+          "name": "raid_plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "write_in_class": {
+          "name": "write_in_class",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_group": {
+          "name": "default_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_position": {
+          "name": "default_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_character__raid_plan_id_idx": {
+          "name": "raid_plan_character__raid_plan_id_idx",
+          "columns": [
+            {
+              "expression": "raid_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_plan_character__character_id_idx": {
+          "name": "raid_plan_character__character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_character_raid_plan_id_raid_plan_id_fk": {
+          "name": "raid_plan_character_raid_plan_id_raid_plan_id_fk",
+          "tableFrom": "raid_plan_character",
+          "tableTo": "raid_plan",
+          "columnsFrom": ["raid_plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_plan_character_character_id_character_character_id_fk": {
+          "name": "raid_plan_character_character_id_character_character_id_fk",
+          "tableFrom": "raid_plan_character",
+          "tableTo": "character",
+          "columnsFrom": ["character_id"],
+          "columnsTo": ["character_id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_encounter_aa_slot": {
+      "name": "raid_plan_encounter_aa_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "encounter_id": {
+          "name": "encounter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raid_plan_id": {
+          "name": "raid_plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_character_id": {
+          "name": "plan_character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_name": {
+          "name": "slot_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "aa_slot__encounter_id_idx": {
+          "name": "aa_slot__encounter_id_idx",
+          "columns": [
+            {
+              "expression": "encounter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aa_slot__raid_plan_id_idx": {
+          "name": "aa_slot__raid_plan_id_idx",
+          "columns": [
+            {
+              "expression": "raid_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aa_slot__plan_character_id_idx": {
+          "name": "aa_slot__plan_character_id_idx",
+          "columns": [
+            {
+              "expression": "plan_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_encounter_aa_slot_encounter_id_raid_plan_encounter_id_fk": {
+          "name": "raid_plan_encounter_aa_slot_encounter_id_raid_plan_encounter_id_fk",
+          "tableFrom": "raid_plan_encounter_aa_slot",
+          "tableTo": "raid_plan_encounter",
+          "columnsFrom": ["encounter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_plan_encounter_aa_slot_raid_plan_id_raid_plan_id_fk": {
+          "name": "raid_plan_encounter_aa_slot_raid_plan_id_raid_plan_id_fk",
+          "tableFrom": "raid_plan_encounter_aa_slot",
+          "tableTo": "raid_plan",
+          "columnsFrom": ["raid_plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_plan_encounter_aa_slot_plan_character_id_raid_plan_character_id_fk": {
+          "name": "raid_plan_encounter_aa_slot_plan_character_id_raid_plan_character_id_fk",
+          "tableFrom": "raid_plan_encounter_aa_slot",
+          "tableTo": "raid_plan_character",
+          "columnsFrom": ["plan_character_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_encounter_assignment": {
+      "name": "raid_plan_encounter_assignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "encounter_id": {
+          "name": "encounter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_character_id": {
+          "name": "plan_character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_encounter_assignment__encounter_id_idx": {
+          "name": "raid_plan_encounter_assignment__encounter_id_idx",
+          "columns": [
+            {
+              "expression": "encounter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_plan_encounter_assignment__plan_character_id_idx": {
+          "name": "raid_plan_encounter_assignment__plan_character_id_idx",
+          "columns": [
+            {
+              "expression": "plan_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_encounter_assignment_encounter_id_raid_plan_encounter_id_fk": {
+          "name": "raid_plan_encounter_assignment_encounter_id_raid_plan_encounter_id_fk",
+          "tableFrom": "raid_plan_encounter_assignment",
+          "tableTo": "raid_plan_encounter",
+          "columnsFrom": ["encounter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_plan_encounter_assignment_plan_character_id_raid_plan_character_id_fk": {
+          "name": "raid_plan_encounter_assignment_plan_character_id_raid_plan_character_id_fk",
+          "tableFrom": "raid_plan_encounter_assignment",
+          "tableTo": "raid_plan_character",
+          "columnsFrom": ["plan_character_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_encounter_group": {
+      "name": "raid_plan_encounter_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raid_plan_id": {
+          "name": "raid_plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_encounter_group__raid_plan_id_idx": {
+          "name": "raid_plan_encounter_group__raid_plan_id_idx",
+          "columns": [
+            {
+              "expression": "raid_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_encounter_group_raid_plan_id_raid_plan_id_fk": {
+          "name": "raid_plan_encounter_group_raid_plan_id_raid_plan_id_fk",
+          "tableFrom": "raid_plan_encounter_group",
+          "tableTo": "raid_plan",
+          "columnsFrom": ["raid_plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_encounter": {
+      "name": "raid_plan_encounter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raid_plan_id": {
+          "name": "raid_plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encounter_key": {
+          "name": "encounter_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_name": {
+          "name": "encounter_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "use_default_groups": {
+          "name": "use_default_groups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "aa_template": {
+          "name": "aa_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_custom_aa": {
+          "name": "use_custom_aa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_encounter__raid_plan_id_idx": {
+          "name": "raid_plan_encounter__raid_plan_id_idx",
+          "columns": [
+            {
+              "expression": "raid_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_plan_encounter__group_id_idx": {
+          "name": "raid_plan_encounter__group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_encounter_raid_plan_id_raid_plan_id_fk": {
+          "name": "raid_plan_encounter_raid_plan_id_raid_plan_id_fk",
+          "tableFrom": "raid_plan_encounter",
+          "tableTo": "raid_plan",
+          "columnsFrom": ["raid_plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_plan_encounter_group_id_raid_plan_encounter_group_id_fk": {
+          "name": "raid_plan_encounter_group_id_raid_plan_encounter_group_id_fk",
+          "tableFrom": "raid_plan_encounter",
+          "tableTo": "raid_plan_encounter_group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_presence": {
+      "name": "raid_plan_presence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raid_plan_id": {
+          "name": "raid_plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_session_id": {
+          "name": "client_session_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewing'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "raid_plan_presence__raid_plan_id_idx": {
+          "name": "raid_plan_presence__raid_plan_id_idx",
+          "columns": [
+            {
+              "expression": "raid_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_plan_presence__user_id_idx": {
+          "name": "raid_plan_presence__user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_plan_presence__last_seen_at_idx": {
+          "name": "raid_plan_presence__last_seen_at_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_plan_presence__plan_session_idx": {
+          "name": "raid_plan_presence__plan_session_idx",
+          "columns": [
+            {
+              "expression": "raid_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_presence_raid_plan_id_raid_plan_id_fk": {
+          "name": "raid_plan_presence_raid_plan_id_raid_plan_id_fk",
+          "tableFrom": "raid_plan_presence",
+          "tableTo": "raid_plan",
+          "columnsFrom": ["raid_plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_plan_presence_user_id_auth_user_id_fk": {
+          "name": "raid_plan_presence_user_id_auth_user_id_fk",
+          "tableFrom": "raid_plan_presence",
+          "tableTo": "auth_user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_template_encounter_group": {
+      "name": "raid_plan_template_encounter_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_template_encounter_group__template_id_idx": {
+          "name": "raid_plan_template_encounter_group__template_id_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_template_encounter_group_template_id_raid_plan_template_id_fk": {
+          "name": "raid_plan_template_encounter_group_template_id_raid_plan_template_id_fk",
+          "tableFrom": "raid_plan_template_encounter_group",
+          "tableTo": "raid_plan_template",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_template_encounter": {
+      "name": "raid_plan_template_encounter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encounter_key": {
+          "name": "encounter_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_name": {
+          "name": "encounter_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "aa_template": {
+          "name": "aa_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_template_encounter__template_id_idx": {
+          "name": "raid_plan_template_encounter__template_id_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_plan_template_encounter__group_id_idx": {
+          "name": "raid_plan_template_encounter__group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_template_encounter_template_id_raid_plan_template_id_fk": {
+          "name": "raid_plan_template_encounter_template_id_raid_plan_template_id_fk",
+          "tableFrom": "raid_plan_template_encounter",
+          "tableTo": "raid_plan_template",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_plan_template_encounter_group_id_raid_plan_template_encounter_group_id_fk": {
+          "name": "raid_plan_template_encounter_group_id_raid_plan_template_encounter_group_id_fk",
+          "tableFrom": "raid_plan_template_encounter",
+          "tableTo": "raid_plan_template_encounter_group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_template": {
+      "name": "raid_plan_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone_name": {
+          "name": "zone_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_group_count": {
+          "name": "default_group_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "default_aa_template": {
+          "name": "default_aa_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_template__zone_id_idx": {
+          "name": "raid_plan_template__zone_id_idx",
+          "columns": [
+            {
+              "expression": "zone_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_template_created_by_auth_user_id_fk": {
+          "name": "raid_plan_template_created_by_auth_user_id_fk",
+          "tableFrom": "raid_plan_template",
+          "tableTo": "auth_user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan": {
+      "name": "raid_plan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raid_helper_event_id": {
+          "name": "raid_helper_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_aa_template": {
+          "name": "default_aa_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_default_aa": {
+          "name": "use_default_aa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan__raid_helper_event_id_idx": {
+          "name": "raid_plan__raid_helper_event_id_idx",
+          "columns": [
+            {
+              "expression": "raid_helper_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_plan__event_id_idx": {
+          "name": "raid_plan__event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_event_id_raid_raid_id_fk": {
+          "name": "raid_plan_event_id_raid_raid_id_fk",
+          "tableFrom": "raid_plan",
+          "tableTo": "raid",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["raid_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_plan_created_by_auth_user_id_fk": {
+          "name": "raid_plan_created_by_auth_user_id_fk",
+          "tableFrom": "raid_plan",
+          "tableTo": "auth_user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "raid_plan_updated_by_auth_user_id_fk": {
+          "name": "raid_plan_updated_by_auth_user_id_fk",
+          "tableFrom": "raid_plan",
+          "tableTo": "auth_user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid": {
+      "name": "raid",
+      "schema": "",
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_weight": {
+          "name": "attendance_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "zone": {
+          "name": "zone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid__raid_id_idx": {
+          "name": "raid__raid_id_idx",
+          "columns": [
+            {
+              "expression": "raid_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_created_by_auth_user_id_fk": {
+          "name": "raid_created_by_auth_user_id_fk",
+          "tableFrom": "raid",
+          "tableTo": "auth_user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "raid_updated_by_auth_user_id_fk": {
+          "name": "raid_updated_by_auth_user_id_fk",
+          "tableFrom": "raid",
+          "tableTo": "auth_user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipes": {
+      "name": "recipes",
+      "schema": "",
+      "columns": {
+        "recipe_spell_id": {
+          "name": "recipe_spell_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profession": {
+          "name": "profession",
+          "type": "profession",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe": {
+          "name": "recipe",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_common": {
+          "name": "is_common",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recipes_created_by_auth_user_id_fk": {
+          "name": "recipes_created_by_auth_user_id_fk",
+          "tableFrom": "recipes",
+          "tableTo": "auth_user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "recipes_updated_by_auth_user_id_fk": {
+          "name": "recipes_updated_by_auth_user_id_fk",
+          "tableFrom": "recipes",
+          "tableTo": "auth_user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_raid_manager": {
+          "name": "is_raid_manager",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user__id_idx": {
+          "name": "user__id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification_token": {
+      "name": "auth_verification_token",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "auth_verification_token_identifier_token_pk": {
+          "name": "auth_verification_token_identifier_token_pk",
+          "columns": ["identifier", "token"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.created_via": {
+      "name": "created_via",
+      "schema": "public",
+      "values": ["ui", "wcl_raid_log_import"]
+    },
+    "public.profession": {
+      "name": "profession",
+      "schema": "public",
+      "values": [
+        "Alchemy",
+        "Blacksmithing",
+        "Enchanting",
+        "Engineering",
+        "Tailoring",
+        "Leatherworking",
+        "Cooking"
+      ]
+    },
+    "public.updated_via": {
+      "name": "updated_via",
+      "schema": "public",
+      "values": ["ui", "wcl_raid_log_import"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "views.all_raids_current_lockout": {
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_weight": {
+          "name": "attendance_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "zone": {
+          "name": "zone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "name": "all_raids_current_lockout",
+      "schema": "views",
+      "isExisting": true,
+      "materialized": false
+    },
+    "views.primary_raid_attendance_l6lockoutwk": {
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weighted_attendance": {
+          "name": "weighted_attendance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weighted_raid_total": {
+          "name": "weighted_raid_total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weighted_attendance_pct": {
+          "name": "weighted_attendance_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "name": "primary_raid_attendance_l6lockoutwk",
+      "schema": "views",
+      "isExisting": true,
+      "materialized": false
+    },
+    "views.primary_raid_attendee_and_bench_map": {
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_character_id": {
+          "name": "primary_character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_character_ids": {
+          "name": "all_character_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendee_or_bench": {
+          "name": "attendee_or_bench",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_characters": {
+          "name": "all_characters",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raid_log_ids": {
+          "name": "raid_log_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "name": "primary_raid_attendee_and_bench_map",
+      "schema": "views",
+      "isExisting": true,
+      "materialized": false
+    },
+    "views.primary_raid_attendee_map": {
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_character_id": {
+          "name": "primary_character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attending_character_ids": {
+          "name": "attending_character_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "name": "primary_raid_attendee_map",
+      "schema": "views",
+      "isExisting": true,
+      "materialized": false
+    },
+    "views.primary_raid_bench_map": {
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_character_id": {
+          "name": "primary_character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bench_character_ids": {
+          "name": "bench_character_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "name": "primary_raid_bench_map",
+      "schema": "views",
+      "isExisting": true,
+      "materialized": false
+    },
+    "views.report_dates": {
+      "columns": {
+        "report_period_start": {
+          "name": "report_period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_period_end": {
+          "name": "report_period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "name": "report_dates",
+      "schema": "views",
+      "isExisting": true,
+      "materialized": false
+    },
+    "views.tracked_raids_current_lockout": {
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_weight": {
+          "name": "attendance_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "zone": {
+          "name": "zone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "name": "tracked_raids_current_lockout",
+      "schema": "views",
+      "isExisting": true,
+      "materialized": false
+    },
+    "views.tracked_raids_l6lockoutwk": {
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_weight": {
+          "name": "attendance_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "zone": {
+          "name": "zone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lockout_week": {
+          "name": "lockout_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "name": "tracked_raids_l6lockoutwk",
+      "schema": "views",
+      "isExisting": true,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1774953022078,
       "tag": "0018_touch-raid-plan-updated-at",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1775774695817,
+      "tag": "0019_gifted_nextwave",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/raid-planner/raid-plan-detail.tsx
+++ b/src/components/raid-planner/raid-plan-detail.tsx
@@ -78,11 +78,16 @@ export function RaidPlanDetail({
     pushDefaultAAMutation,
     isPollingActive,
     startPolling,
+    presence,
+    markPresenceEditing,
   } = mutations;
 
   const utils = api.useUtils();
   const createEncounterMutation = api.raidPlan.createEncounter.useMutation({
-    onSuccess: () => void refetch(),
+    onSuccess: () => {
+      markPresenceEditing();
+      void refetch();
+    },
   });
   const createEncounterGroupMutation =
     api.raidPlan.createEncounterGroup.useMutation({
@@ -113,6 +118,7 @@ export function RaidPlanDetail({
           utils.raidPlan.getById.setData({ planId: pid }, context.prev);
       },
       onSettled: (_data, _err, { planId: pid }) => {
+        markPresenceEditing();
         void utils.raidPlan.getById.invalidate({ planId: pid });
       },
     });
@@ -145,6 +151,7 @@ export function RaidPlanDetail({
           utils.raidPlan.getById.setData({ planId }, context.prev);
       },
       onSettled: () => {
+        markPresenceEditing();
         void utils.raidPlan.getById.invalidate({ planId });
       },
     });
@@ -163,6 +170,7 @@ export function RaidPlanDetail({
       }
     },
     onSettled: () => {
+      markPresenceEditing();
       void utils.raidPlan.getById.invalidate({ planId });
     },
   });
@@ -217,6 +225,7 @@ export function RaidPlanDetail({
           utils.raidPlan.getById.setData({ planId }, context.prev);
       },
       onSettled: () => {
+        markPresenceEditing();
         void utils.raidPlan.getById.invalidate({ planId });
       },
     });
@@ -315,6 +324,10 @@ export function RaidPlanDetail({
         raidHelperEventId={plan.raidHelperEventId}
         startAt={plan.startAt}
         event={plan.event}
+        creator={plan.creator}
+        lastEditor={plan.lastEditor}
+        lastModifiedAt={plan.lastModifiedAt}
+        presence={presence}
         onNameUpdate={refetch}
         isPublic={plan.isPublic}
         onTogglePublic={(isPublic) =>
@@ -325,6 +338,7 @@ export function RaidPlanDetail({
         isExportingAA={isExportingAA}
         isPollingActive={isPollingActive}
         onRestartPolling={startPolling}
+        onEditActivity={markPresenceEditing}
       />
 
       <Separator className="my-2" />
@@ -340,7 +354,10 @@ export function RaidPlanDetail({
             leftActions={
               <AddEncounterDialog
                 planId={planId}
-                onEncounterCreated={refetch}
+                onEncounterCreated={() => {
+                  markPresenceEditing();
+                  void refetch();
+                }}
               />
             }
             actions={

--- a/src/components/raid-planner/raid-plan-header.tsx
+++ b/src/components/raid-planner/raid-plan-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import { formatDistanceToNow } from "date-fns";
 import { useRouter } from "next/navigation";
 import {
   Trash2,
@@ -15,7 +16,11 @@ import {
   Settings,
   Globe,
   GlobeLock,
+  Eye,
+  PencilLine,
+  Users,
 } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
@@ -65,6 +70,31 @@ import { PollingIndicator } from "./polling-indicator";
 
 const ZONE_BADGE_CLASSES = ZONE_ACCENT_CLASSES;
 
+interface RaidPlanPerson {
+  id: string | null;
+  name: string | null;
+  image: string | null;
+}
+
+interface RaidPlanPresenceUser {
+  userId: string;
+  name: string;
+  image: string | null;
+  mode: "viewing" | "editing";
+  lastSeenAt: Date;
+  isCurrentUser: boolean;
+}
+
+function getInitials(name: string | null | undefined) {
+  if (!name) return "?";
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
 interface RaidPlanHeaderProps {
   planId: string;
   name: string;
@@ -72,6 +102,10 @@ interface RaidPlanHeaderProps {
   raidHelperEventId: string;
   startAt?: Date | null;
   event: { raidId: number; name: string; date: string } | null;
+  creator?: RaidPlanPerson | null;
+  lastEditor?: RaidPlanPerson | null;
+  lastModifiedAt?: Date | null;
+  presence?: RaidPlanPresenceUser[];
   onNameUpdate?: () => void;
   isPublic?: boolean;
   onTogglePublic?: (isPublic: boolean) => void;
@@ -80,6 +114,7 @@ interface RaidPlanHeaderProps {
   isExportingAA?: boolean;
   isPollingActive?: boolean;
   onRestartPolling?: () => void;
+  onEditActivity?: () => void;
 }
 
 export function RaidPlanHeader({
@@ -89,6 +124,10 @@ export function RaidPlanHeader({
   raidHelperEventId,
   startAt,
   event,
+  creator,
+  lastEditor,
+  lastModifiedAt,
+  presence = [],
   onNameUpdate,
   isPublic,
   onTogglePublic,
@@ -97,6 +136,7 @@ export function RaidPlanHeader({
   isExportingAA,
   isPollingActive = true,
   onRestartPolling,
+  onEditActivity,
 }: RaidPlanHeaderProps) {
   const router = useRouter();
   const { toast } = useToast();
@@ -171,6 +211,7 @@ export function RaidPlanHeader({
       });
     },
     onSettled: () => {
+      onEditActivity?.();
       void utils.raidPlan.getById.invalidate({ planId });
     },
   });
@@ -224,6 +265,17 @@ export function RaidPlanHeader({
     zoneId === CUSTOM_ZONE_ID
       ? CUSTOM_ZONE_DISPLAY_NAME
       : (INSTANCE_TO_ZONE[zoneId] ?? zoneId);
+  const visiblePresence = presence.slice(0, 4);
+  const overflowPresenceCount = Math.max(
+    0,
+    presence.length - visiblePresence.length,
+  );
+  const lastEditedLabel =
+    lastModifiedAt && lastEditor?.name
+      ? `Last edited by ${lastEditor.name} ${formatDistanceToNow(new Date(lastModifiedAt), { addSuffix: true })}`
+      : lastModifiedAt
+        ? `Last updated ${formatDistanceToNow(new Date(lastModifiedAt), { addSuffix: true })}`
+        : null;
 
   return (
     <div className="flex gap-4">
@@ -331,6 +383,12 @@ export function RaidPlanHeader({
             </div>
           )}
         </div>
+        {!isEditing && (
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+            {creator?.name ? <span>Created by {creator.name}</span> : null}
+            {lastEditedLabel ? <span>{lastEditedLabel}</span> : null}
+          </div>
+        )}
       </div>
 
       {/* Right column: buttons */}
@@ -345,9 +403,9 @@ export function RaidPlanHeader({
                   side="left"
                   activeTooltip={
                     <div className="flex w-fit flex-col gap-0.5 whitespace-nowrap">
-                      <span className="font-bold">Live Updates</span>
+                      <span className="font-bold">Sync Active</span>
                       <span className="text-xs">
-                        Syncing near-real-time updates from other users.
+                        This tab is polling for near-real-time planner updates.
                       </span>
                     </div>
                   }
@@ -355,11 +413,86 @@ export function RaidPlanHeader({
                     <div className="flex w-fit flex-col gap-0.5 whitespace-nowrap">
                       <span className="font-bold">Polling Paused</span>
                       <span className="text-xs">
-                        No updates in the last 5 minutes. Click to resume.
+                        This tab stopped polling after 5 minutes of inactivity.
+                        Click to resume.
                       </span>
                     </div>
                   }
                 />
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="flex items-center gap-1 rounded-full border border-border/60 bg-background/80 px-2 py-1">
+                        <Users className="h-3.5 w-3.5 text-muted-foreground" />
+                        <div className="flex -space-x-2">
+                          {visiblePresence.length > 0 ? (
+                            visiblePresence.map((user) => (
+                              <Avatar
+                                key={user.userId}
+                                className={`h-6 w-6 border-2 ${
+                                  user.mode === "editing"
+                                    ? "border-primary ring-1 ring-primary/30"
+                                    : "border-background"
+                                }`}
+                              >
+                                <AvatarImage src={user.image ?? undefined} />
+                                <AvatarFallback className="text-[10px]">
+                                  {getInitials(user.name)}
+                                </AvatarFallback>
+                              </Avatar>
+                            ))
+                          ) : (
+                            <span className="text-xs text-muted-foreground">
+                              Just you
+                            </span>
+                          )}
+                          {overflowPresenceCount > 0 ? (
+                            <div className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-background bg-muted text-[10px] font-medium text-muted-foreground">
+                              +{overflowPresenceCount}
+                            </div>
+                          ) : null}
+                        </div>
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent
+                      side="left"
+                      className="dark border-none bg-secondary text-muted-foreground"
+                    >
+                      <div className="space-y-1">
+                        <p className="font-bold text-foreground">
+                          Active on this plan
+                        </p>
+                        {presence.length > 0 ? (
+                          presence.map((user) => (
+                            <div
+                              key={user.userId}
+                              className="flex items-center gap-2 text-xs"
+                            >
+                              {user.mode === "editing" ? (
+                                <PencilLine className="h-3 w-3 text-primary" />
+                              ) : (
+                                <Eye className="h-3 w-3" />
+                              )}
+                              <span>
+                                {user.name}
+                                {user.isCurrentUser ? " (You)" : ""}
+                              </span>
+                              <span className="text-[11px] uppercase tracking-wide text-muted-foreground/80">
+                                {user.mode === "editing"
+                                  ? "Editing now"
+                                  : "Viewing"}
+                              </span>
+                            </div>
+                          ))
+                        ) : (
+                          <p className="text-xs">
+                            No active viewers right now.
+                          </p>
+                        )}
+                      </div>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
                 {onTogglePublic && (
                   <>
                     <TooltipProvider>

--- a/src/hooks/use-raid-plan-handlers.tsx
+++ b/src/hooks/use-raid-plan-handlers.tsx
@@ -42,6 +42,7 @@ export function useRaidPlanHandlers({
     updateEncounterMutation,
     refreshCharactersMutation,
     assignAASlotMutation,
+    markPresenceEditing,
   } = mutations;
 
   const { toast } = useToast();
@@ -127,13 +128,14 @@ export function useRaidPlanHandlers({
             });
           },
           onSettled: () => {
+            markPresenceEditing();
             // Refetch to ensure consistency
             void utils.raidPlan.getById.invalidate({ planId });
           },
         },
       );
     },
-    [planId, updateCharacterMutation, utils, toast],
+    [markPresenceEditing, planId, updateCharacterMutation, utils, toast],
   );
 
   const handleCharacterUpdate = useCallback(
@@ -252,13 +254,14 @@ export function useRaidPlanHandlers({
             });
           },
           onSettled: () => {
+            markPresenceEditing();
             // Refetch to ensure consistency and get the real ID
             void utils.raidPlan.getById.invalidate({ planId });
           },
         },
       );
     },
-    [planId, addCharacterMutation, utils, toast],
+    [addCharacterMutation, markPresenceEditing, planId, utils, toast],
   );
 
   const handleCharacterDelete = useCallback(
@@ -295,13 +298,14 @@ export function useRaidPlanHandlers({
             });
           },
           onSettled: () => {
+            markPresenceEditing();
             // Refetch to ensure consistency
             void utils.raidPlan.getById.invalidate({ planId });
           },
         },
       );
     },
-    [planId, deleteCharacterMutation, utils, toast],
+    [deleteCharacterMutation, markPresenceEditing, planId, utils, toast],
   );
 
   const exportMRT = useCallback(

--- a/src/hooks/use-raid-plan-mutations.ts
+++ b/src/hooks/use-raid-plan-mutations.ts
@@ -2,6 +2,13 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { api } from "~/trpc/react";
 import { useToast } from "~/hooks/use-toast";
 
+const POLLING_INTERVAL = 5000;
+const PRESENCE_POLLING_INTERVAL = 15000;
+const INACTIVITY_TIMEOUT = 5 * 60 * 1000;
+const PRESENCE_HEARTBEAT_INTERVAL = 30000;
+const PRESENCE_EDITING_WINDOW = 90000;
+const CLIENT_SESSION_STORAGE_KEY = "raid-plan-client-session-id";
+
 interface UseRaidPlanMutationsOptions {
   planId: string;
   onEncounterDeleted?: () => void;
@@ -14,11 +21,10 @@ export function useRaidPlanMutations({
   const { toast } = useToast();
   const utils = api.useUtils();
   const [isPollingActive, setIsPollingActive] = useState(true);
+  const [clientSessionId, setClientSessionId] = useState<string | null>(null);
   const lastActivityRef = useRef(Date.now());
+  const lastEditAtRef = useRef(0);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
-
-  const POLLING_INTERVAL = 5000;
-  const INACTIVITY_TIMEOUT = 5 * 60 * 1000; // 5 minutes
 
   const startPolling = useCallback(() => {
     lastActivityRef.current = Date.now();
@@ -48,7 +54,23 @@ export function useRaidPlanMutations({
     return () => {
       if (timerRef.current) clearInterval(timerRef.current);
     };
-  }, [isPollingActive, INACTIVITY_TIMEOUT]);
+  }, [isPollingActive]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const existingSessionId = window.sessionStorage.getItem(
+      CLIENT_SESSION_STORAGE_KEY,
+    );
+    if (existingSessionId) {
+      setClientSessionId(existingSessionId);
+      return;
+    }
+
+    const nextSessionId = crypto.randomUUID();
+    window.sessionStorage.setItem(CLIENT_SESSION_STORAGE_KEY, nextSessionId);
+    setClientSessionId(nextSessionId);
+  }, []);
 
   const {
     data: plan,
@@ -62,6 +84,89 @@ export function useRaidPlanMutations({
       refetchIntervalInBackground: false,
     },
   );
+
+  const { data: presence = [] } = api.raidPlan.getPresence.useQuery(
+    { planId },
+    {
+      refetchInterval: isPollingActive ? PRESENCE_POLLING_INTERVAL : false,
+      refetchIntervalInBackground: false,
+      enabled: !!clientSessionId,
+    },
+  );
+
+  const upsertPresenceMutation = api.raidPlan.upsertPresence.useMutation();
+  const clearPresenceMutation = api.raidPlan.clearPresence.useMutation();
+  const upsertPresenceRef = useRef(upsertPresenceMutation);
+  const clearPresenceRef = useRef(clearPresenceMutation);
+
+  useEffect(() => {
+    upsertPresenceRef.current = upsertPresenceMutation;
+    clearPresenceRef.current = clearPresenceMutation;
+  }, [upsertPresenceMutation, clearPresenceMutation]);
+
+  const sendPresenceHeartbeat = useCallback(
+    (mode?: "viewing" | "editing") => {
+      if (!clientSessionId) return;
+      if (
+        typeof document !== "undefined" &&
+        document.visibilityState !== "visible"
+      ) {
+        return;
+      }
+
+      const nextMode =
+        mode ??
+        (Date.now() - lastEditAtRef.current <= PRESENCE_EDITING_WINDOW
+          ? "editing"
+          : "viewing");
+
+      upsertPresenceRef.current.mutate({
+        planId,
+        clientSessionId,
+        mode: nextMode,
+      });
+    },
+    [clientSessionId, planId],
+  );
+
+  const markPresenceEditing = useCallback(() => {
+    lastEditAtRef.current = Date.now();
+    trackActivity();
+    sendPresenceHeartbeat("editing");
+  }, [sendPresenceHeartbeat, trackActivity]);
+
+  useEffect(() => {
+    if (!clientSessionId) return;
+
+    sendPresenceHeartbeat();
+
+    const intervalId = window.setInterval(() => {
+      sendPresenceHeartbeat();
+    }, PRESENCE_HEARTBEAT_INTERVAL);
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        sendPresenceHeartbeat();
+      }
+    };
+
+    const clearPresence = () => {
+      clearPresenceRef.current.mutate({
+        planId,
+        clientSessionId,
+      });
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("pagehide", clearPresence);
+
+    return () => {
+      window.clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("pagehide", clearPresence);
+      clearPresence();
+    };
+  }, [clientSessionId, planId, sendPresenceHeartbeat]);
 
   const lastSeenRevisionRef = useRef<string | null>(null);
   useEffect(() => {
@@ -104,7 +209,7 @@ export function useRaidPlanMutations({
       if (ctx?.prev) utils.raidPlan.getById.setData({ planId }, ctx.prev);
     },
     onSettled: () => {
-      trackActivity();
+      markPresenceEditing();
       void utils.raidPlan.getById.invalidate({ planId });
     },
   });
@@ -138,7 +243,7 @@ export function useRaidPlanMutations({
       });
     },
     onSettled: () => {
-      trackActivity();
+      markPresenceEditing();
       void utils.raidPlan.getById.invalidate({ planId });
     },
   });
@@ -146,7 +251,7 @@ export function useRaidPlanMutations({
   const resetEncounterMutation =
     api.raidPlan.resetEncounterToDefault.useMutation({
       onSuccess: (data) => {
-        trackActivity();
+        markPresenceEditing();
         toast({
           title: "Reset to default",
           description: `Encounter groups reset to match default (${data.count} assignments)`,
@@ -189,7 +294,7 @@ export function useRaidPlanMutations({
       if (ctx?.prev) utils.raidPlan.getById.setData({ planId }, ctx.prev);
     },
     onSettled: () => {
-      trackActivity();
+      markPresenceEditing();
       void utils.raidPlan.getById.invalidate({ planId });
     },
   });
@@ -232,7 +337,7 @@ export function useRaidPlanMutations({
       if (ctx?.prev) utils.raidPlan.getById.setData({ planId }, ctx.prev);
     },
     onSettled: () => {
-      trackActivity();
+      markPresenceEditing();
       void utils.raidPlan.getById.invalidate({ planId });
     },
   });
@@ -282,7 +387,7 @@ export function useRaidPlanMutations({
         if (ctx?.prev) utils.raidPlan.getById.setData({ planId }, ctx.prev);
       },
       onSettled: () => {
-        trackActivity();
+        markPresenceEditing();
         void utils.raidPlan.getById.invalidate({ planId });
       },
     });
@@ -382,14 +487,14 @@ export function useRaidPlanMutations({
         if (ctx?.prev) utils.raidPlan.getById.setData({ planId }, ctx.prev);
       },
       onSettled: () => {
-        trackActivity();
+        markPresenceEditing();
         void utils.raidPlan.getById.invalidate({ planId });
       },
     });
 
   const refreshCharactersMutation = api.raidPlan.refreshCharacters.useMutation({
     onSuccess: (data) => {
-      trackActivity();
+      markPresenceEditing();
       toast({
         title: "Roster refreshed",
         description: `+${data.added} added, ${data.updated} updated, -${data.removed} removed`,
@@ -407,7 +512,7 @@ export function useRaidPlanMutations({
 
   const updatePlanMutation = api.raidPlan.update.useMutation({
     onSuccess: () => {
-      trackActivity();
+      markPresenceEditing();
       void refetch();
     },
     onError: (error) => {
@@ -476,7 +581,7 @@ export function useRaidPlanMutations({
         });
       },
       onSettled: () => {
-        trackActivity();
+        markPresenceEditing();
         void utils.raidPlan.getById.invalidate({ planId });
       },
     },
@@ -522,7 +627,7 @@ export function useRaidPlanMutations({
         });
       },
       onSettled: () => {
-        trackActivity();
+        markPresenceEditing();
         void utils.raidPlan.getById.invalidate({ planId });
       },
     });
@@ -568,7 +673,7 @@ export function useRaidPlanMutations({
         });
       },
       onSettled: () => {
-        trackActivity();
+        markPresenceEditing();
         void utils.raidPlan.getById.invalidate({ planId });
       },
     });
@@ -598,7 +703,7 @@ export function useRaidPlanMutations({
       if (ctx?.prev) utils.raidPlan.getById.setData({ planId }, ctx.prev);
     },
     onSettled: () => {
-      trackActivity();
+      markPresenceEditing();
       void utils.raidPlan.getById.invalidate({ planId });
     },
   });
@@ -628,7 +733,7 @@ export function useRaidPlanMutations({
         });
       },
       onSettled: () => {
-        trackActivity();
+        markPresenceEditing();
         void utils.raidPlan.getById.invalidate({ planId });
       },
     });
@@ -680,7 +785,7 @@ export function useRaidPlanMutations({
         });
       },
       onSettled: () => {
-        trackActivity();
+        markPresenceEditing();
         void utils.raidPlan.getById.invalidate({ planId });
       },
     });
@@ -712,7 +817,7 @@ export function useRaidPlanMutations({
         });
       },
       onSettled: () => {
-        trackActivity();
+        markPresenceEditing();
         void utils.raidPlan.getById.invalidate({ planId });
       },
     });
@@ -720,7 +825,7 @@ export function useRaidPlanMutations({
   const pushDefaultAAMutation =
     api.raidPlan.pushDefaultAAAssignments.useMutation({
       onSuccess: (data) => {
-        trackActivity();
+        markPresenceEditing();
         toast({
           title: "Assignments pushed",
           description: `Pushed ${data.totalSlotsPushed} slot${data.totalSlotsPushed !== 1 ? "s" : ""} to ${data.encounters.length} encounter${data.encounters.length !== 1 ? "s" : ""}`,
@@ -762,8 +867,10 @@ export function useRaidPlanMutations({
     benchEncounterAssignmentsMutation,
     reorderEncountersMutation,
     pushDefaultAAMutation,
+    presence,
     isPollingActive,
     startPolling,
     trackActivity,
+    markPresenceEditing,
   };
 }

--- a/src/server/api/routers/raid-plan.ts
+++ b/src/server/api/routers/raid-plan.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  aliasedTable,
   eq,
   inArray,
   notInArray,
@@ -8,6 +9,8 @@ import {
   and,
   or,
   desc,
+  gte,
+  lt,
   sql,
 } from "drizzle-orm";
 import {
@@ -23,15 +26,96 @@ import {
   raidPlanEncounters,
   raidPlanEncounterAssignments,
   raidPlanEncounterAASlots,
+  raidPlanPresence,
   raidPlanTemplates,
   raidPlanTemplateEncounters,
   raidPlanTemplateEncounterGroups,
   characters,
   raids,
+  users,
 } from "~/server/db/schema";
 import { TRPCError } from "@trpc/server";
 import { getSlotNames } from "~/lib/aa-template";
 import { slugifyEncounterName } from "~/server/api/helpers/raid-plan-helpers";
+import { type db as database } from "~/server/db";
+
+const PRESENCE_ACTIVE_WINDOW_MS = 60_000;
+const PRESENCE_RETENTION_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+const creatorUsers = aliasedTable(users, "raid_plan_creator");
+const lastEditorUsers = aliasedTable(users, "raid_plan_last_editor");
+
+type RaidPlanDbClient = Pick<
+  typeof database,
+  "select" | "insert" | "update" | "delete" | "transaction"
+>;
+
+function normalizeUserIdentity<
+  T extends { id: string | null; name: string | null; image: string | null },
+>(user: T | null) {
+  return user?.id ? user : null;
+}
+
+async function touchRaidPlanActor(
+  dbClient: RaidPlanDbClient,
+  raidPlanId: string,
+  userId: string,
+) {
+  await dbClient
+    .update(raidPlans)
+    .set({ updatedById: userId })
+    .where(eq(raidPlans.id, raidPlanId));
+}
+
+async function getRaidPlanIdForEncounter(
+  dbClient: RaidPlanDbClient,
+  encounterId: string,
+) {
+  const result = await dbClient
+    .select({ raidPlanId: raidPlanEncounters.raidPlanId })
+    .from(raidPlanEncounters)
+    .where(eq(raidPlanEncounters.id, encounterId))
+    .limit(1);
+
+  return result[0]?.raidPlanId ?? null;
+}
+
+async function getRaidPlanIdForPlanCharacter(
+  dbClient: RaidPlanDbClient,
+  planCharacterId: string,
+) {
+  const result = await dbClient
+    .select({ raidPlanId: raidPlanCharacters.raidPlanId })
+    .from(raidPlanCharacters)
+    .where(eq(raidPlanCharacters.id, planCharacterId))
+    .limit(1);
+
+  return result[0]?.raidPlanId ?? null;
+}
+
+async function getRaidPlanIdForEncounterGroup(
+  dbClient: RaidPlanDbClient,
+  groupId: string,
+) {
+  const result = await dbClient
+    .select({ raidPlanId: raidPlanEncounterGroups.raidPlanId })
+    .from(raidPlanEncounterGroups)
+    .where(eq(raidPlanEncounterGroups.id, groupId))
+    .limit(1);
+
+  return result[0]?.raidPlanId ?? null;
+}
+
+async function cleanupStalePresence(dbClient: RaidPlanDbClient) {
+  await dbClient
+    .delete(raidPlanPresence)
+    .where(
+      lt(
+        raidPlanPresence.lastSeenAt,
+        new Date(Date.now() - PRESENCE_RETENTION_WINDOW_MS),
+      ),
+    );
+}
 
 export const raidPlanRouter = createTRPCRouter({
   /**
@@ -120,8 +204,23 @@ export const raidPlanRouter = createTRPCRouter({
           useDefaultAA: raidPlans.useDefaultAA,
           isPublic: raidPlans.isPublic,
           lastModifiedAt: sql<Date>`COALESCE(${raidPlans.updatedAt}, ${raidPlans.createdAt})`,
+          creator: {
+            id: creatorUsers.id,
+            name: creatorUsers.name,
+            image: creatorUsers.image,
+          },
+          lastEditor: {
+            id: lastEditorUsers.id,
+            name: lastEditorUsers.name,
+            image: lastEditorUsers.image,
+          },
         })
         .from(raidPlans)
+        .leftJoin(creatorUsers, eq(creatorUsers.id, raidPlans.createdById))
+        .leftJoin(
+          lastEditorUsers,
+          eq(lastEditorUsers.id, raidPlans.updatedById),
+        )
         .where(eq(raidPlans.id, input.planId))
         .limit(1);
 
@@ -260,6 +359,8 @@ export const raidPlanRouter = createTRPCRouter({
 
       return {
         ...plan[0]!,
+        creator: normalizeUserIdentity(plan[0]!.creator),
+        lastEditor: normalizeUserIdentity(plan[0]!.lastEditor),
         event,
         characters: planCharacters,
         encounterGroups,
@@ -267,6 +368,137 @@ export const raidPlanRouter = createTRPCRouter({
         encounterAssignments,
         aaSlotAssignments,
       };
+    }),
+
+  getPresence: raidManagerProcedure
+    .input(z.object({ planId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      await cleanupStalePresence(ctx.db);
+
+      const activePresence = await ctx.db
+        .select({
+          userId: raidPlanPresence.userId,
+          name: users.name,
+          image: users.image,
+          mode: raidPlanPresence.mode,
+          lastSeenAt: raidPlanPresence.lastSeenAt,
+        })
+        .from(raidPlanPresence)
+        .innerJoin(users, eq(users.id, raidPlanPresence.userId))
+        .where(
+          and(
+            eq(raidPlanPresence.raidPlanId, input.planId),
+            gte(
+              raidPlanPresence.lastSeenAt,
+              new Date(Date.now() - PRESENCE_ACTIVE_WINDOW_MS),
+            ),
+          ),
+        );
+
+      const presenceByUser = new Map<
+        string,
+        {
+          userId: string;
+          name: string;
+          image: string | null;
+          mode: "viewing" | "editing";
+          lastSeenAt: Date;
+          isCurrentUser: boolean;
+        }
+      >();
+
+      for (const session of activePresence) {
+        const existing = presenceByUser.get(session.userId);
+        const nextMode =
+          session.mode === "editing" ? "editing" : ("viewing" as const);
+
+        if (!existing) {
+          presenceByUser.set(session.userId, {
+            userId: session.userId,
+            name: session.name ?? "Unknown user",
+            image: session.image,
+            mode: nextMode,
+            lastSeenAt: session.lastSeenAt,
+            isCurrentUser: session.userId === ctx.session.user.id,
+          });
+          continue;
+        }
+
+        existing.mode =
+          existing.mode === "editing" || nextMode === "editing"
+            ? "editing"
+            : "viewing";
+
+        if (session.lastSeenAt > existing.lastSeenAt) {
+          existing.lastSeenAt = session.lastSeenAt;
+        }
+      }
+
+      return Array.from(presenceByUser.values()).sort((a, b) => {
+        if (a.mode !== b.mode) {
+          return a.mode === "editing" ? -1 : 1;
+        }
+
+        return a.name.localeCompare(b.name);
+      });
+    }),
+
+  upsertPresence: raidManagerProcedure
+    .input(
+      z.object({
+        planId: z.string().uuid(),
+        clientSessionId: z.string().min(1).max(128),
+        mode: z.enum(["viewing", "editing"]),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await cleanupStalePresence(ctx.db);
+
+      const now = new Date();
+
+      await ctx.db
+        .insert(raidPlanPresence)
+        .values({
+          raidPlanId: input.planId,
+          userId: ctx.session.user.id,
+          clientSessionId: input.clientSessionId,
+          mode: input.mode,
+          lastSeenAt: now,
+        })
+        .onConflictDoUpdate({
+          target: [
+            raidPlanPresence.raidPlanId,
+            raidPlanPresence.clientSessionId,
+          ],
+          set: {
+            userId: ctx.session.user.id,
+            mode: input.mode,
+            lastSeenAt: now,
+          },
+        });
+
+      return { success: true };
+    }),
+
+  clearPresence: raidManagerProcedure
+    .input(
+      z.object({
+        planId: z.string().uuid(),
+        clientSessionId: z.string().min(1).max(128),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await ctx.db
+        .delete(raidPlanPresence)
+        .where(
+          and(
+            eq(raidPlanPresence.raidPlanId, input.planId),
+            eq(raidPlanPresence.clientSessionId, input.clientSessionId),
+            eq(raidPlanPresence.userId, ctx.session.user.id),
+          ),
+        );
+
+      return { success: true };
     }),
 
   /**
@@ -282,7 +514,7 @@ export const raidPlanRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const result = await ctx.db
         .update(raidPlans)
-        .set({ isPublic: input.isPublic })
+        .set({ isPublic: input.isPublic, updatedById: ctx.session.user.id })
         .where(eq(raidPlans.id, input.planId))
         .returning({ id: raidPlans.id, isPublic: raidPlans.isPublic });
 
@@ -552,6 +784,8 @@ export const raidPlanRouter = createTRPCRouter({
           useDefaultGroups: raidPlanEncounters.useDefaultGroups,
         });
 
+      await touchRaidPlanActor(ctx.db, input.planId, ctx.session.user.id);
+
       return newEncounter[0]!;
     }),
 
@@ -598,6 +832,7 @@ export const raidPlanRouter = createTRPCRouter({
         return { success: true };
       }
 
+      const planId = await getRaidPlanIdForEncounter(ctx.db, input.encounterId);
       const result = await ctx.db
         .update(raidPlanEncounters)
         .set(updates)
@@ -672,6 +907,10 @@ export const raidPlanRouter = createTRPCRouter({
         }
       }
 
+      if (planId) {
+        await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
+      }
+
       return { success: true };
     }),
 
@@ -681,6 +920,7 @@ export const raidPlanRouter = createTRPCRouter({
   deleteEncounter: raidManagerProcedure
     .input(z.object({ encounterId: z.string().uuid() }))
     .mutation(async ({ ctx, input }) => {
+      const planId = await getRaidPlanIdForEncounter(ctx.db, input.encounterId);
       const result = await ctx.db
         .delete(raidPlanEncounters)
         .where(eq(raidPlanEncounters.id, input.encounterId))
@@ -691,6 +931,10 @@ export const raidPlanRouter = createTRPCRouter({
           code: "NOT_FOUND",
           message: "Encounter not found",
         });
+      }
+
+      if (planId) {
+        await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
       }
 
       return { success: true };
@@ -739,7 +983,7 @@ export const raidPlanRouter = createTRPCRouter({
 
       const result = await ctx.db
         .update(raidPlans)
-        .set(updates)
+        .set({ ...updates, updatedById: ctx.session.user.id })
         .where(eq(raidPlans.id, input.planId))
         .returning({ id: raidPlans.id });
 
@@ -818,6 +1062,7 @@ export const raidPlanRouter = createTRPCRouter({
             zoneId: input.zoneId,
             startAt: input.startAt,
             createdById: ctx.session.user.id,
+            updatedById: ctx.session.user.id,
           })
           .returning({ id: raidPlans.id });
 
@@ -1085,6 +1330,10 @@ export const raidPlanRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      const planId = await getRaidPlanIdForPlanCharacter(
+        ctx.db,
+        input.planCharacterId,
+      );
       const result = await ctx.db
         .update(raidPlanCharacters)
         .set({
@@ -1100,6 +1349,10 @@ export const raidPlanRouter = createTRPCRouter({
           code: "NOT_FOUND",
           message: "Plan character not found",
         });
+      }
+
+      if (planId) {
+        await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
       }
 
       return { success: true };
@@ -1118,6 +1371,10 @@ export const raidPlanRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      const planId = await getRaidPlanIdForPlanCharacter(
+        ctx.db,
+        input.planCharacterId,
+      );
       const result = await ctx.db
         .update(raidPlanCharacters)
         .set({
@@ -1132,6 +1389,10 @@ export const raidPlanRouter = createTRPCRouter({
           code: "NOT_FOUND",
           message: "Plan character not found",
         });
+      }
+
+      if (planId) {
+        await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
       }
 
       return { success: true };
@@ -1185,6 +1446,8 @@ export const raidPlanRouter = createTRPCRouter({
           id: raidPlanCharacters.id,
         });
 
+      await touchRaidPlanActor(ctx.db, input.planId, ctx.session.user.id);
+
       return { id: newChar[0]!.id };
     }),
 
@@ -1198,6 +1461,10 @@ export const raidPlanRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      const planId = await getRaidPlanIdForPlanCharacter(
+        ctx.db,
+        input.planCharacterId,
+      );
       const result = await ctx.db
         .delete(raidPlanCharacters)
         .where(eq(raidPlanCharacters.id, input.planCharacterId))
@@ -1208,6 +1475,10 @@ export const raidPlanRouter = createTRPCRouter({
           code: "NOT_FOUND",
           message: "Plan character not found",
         });
+      }
+
+      if (planId) {
+        await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
       }
 
       return { success: true };
@@ -1268,6 +1539,14 @@ export const raidPlanRouter = createTRPCRouter({
           .where(eq(raidPlanCharacters.id, charB.id));
       });
 
+      const planId = await getRaidPlanIdForPlanCharacter(
+        ctx.db,
+        input.planCharacterIdA,
+      );
+      if (planId) {
+        await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
+      }
+
       return { success: true };
     }),
 
@@ -1284,6 +1563,7 @@ export const raidPlanRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      const planId = await getRaidPlanIdForEncounter(ctx.db, input.encounterId);
       const result = await ctx.db
         .update(raidPlanEncounterAssignments)
         .set({
@@ -1310,6 +1590,10 @@ export const raidPlanRouter = createTRPCRouter({
           groupNumber: input.targetGroup,
           position: input.targetPosition,
         });
+      }
+
+      if (planId) {
+        await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
       }
 
       return { success: true };
@@ -1406,6 +1690,11 @@ export const raidPlanRouter = createTRPCRouter({
           .where(eq(raidPlanEncounterAssignments.id, assignB.id));
       });
 
+      const planId = await getRaidPlanIdForEncounter(ctx.db, input.encounterId);
+      if (planId) {
+        await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
+      }
+
       return { success: true };
     }),
 
@@ -1467,6 +1756,8 @@ export const raidPlanRouter = createTRPCRouter({
           .values(newAssignments);
       }
 
+      await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
+
       return { success: true, count: newAssignments.length };
     }),
 
@@ -1495,6 +1786,9 @@ export const raidPlanRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const isEncounter = !!input.encounterId;
+      const planId = input.encounterId
+        ? await getRaidPlanIdForEncounter(ctx.db, input.encounterId)
+        : (input.raidPlanId ?? null);
 
       // Check if character is already in this specific slot
       const existingCheck = isEncounter
@@ -1550,6 +1844,10 @@ export const raidPlanRouter = createTRPCRouter({
         })
         .returning({ id: raidPlanEncounterAASlots.id });
 
+      if (planId) {
+        await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
+      }
+
       return { id: result[0]!.id };
     }),
 
@@ -1573,6 +1871,9 @@ export const raidPlanRouter = createTRPCRouter({
         }),
     )
     .mutation(async ({ ctx, input }) => {
+      const planId = input.encounterId
+        ? await getRaidPlanIdForEncounter(ctx.db, input.encounterId)
+        : (input.raidPlanId ?? null);
       const conditions = [
         eq(raidPlanEncounterAASlots.planCharacterId, input.planCharacterId),
       ];
@@ -1593,6 +1894,10 @@ export const raidPlanRouter = createTRPCRouter({
       }
 
       await ctx.db.delete(raidPlanEncounterAASlots).where(and(...conditions));
+
+      if (planId) {
+        await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
+      }
 
       return { success: true };
     }),
@@ -1620,6 +1925,10 @@ export const raidPlanRouter = createTRPCRouter({
         return { success: true };
       }
 
+      const planId = input.encounterId
+        ? await getRaidPlanIdForEncounter(ctx.db, input.encounterId)
+        : (input.raidPlanId ?? null);
+
       // Batch update using CASE/WHEN for all sort orders in a single query
       const cases = input.planCharacterIds.map(
         (id, i) =>
@@ -1646,6 +1955,10 @@ export const raidPlanRouter = createTRPCRouter({
           ),
         );
 
+      if (planId) {
+        await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
+      }
+
       return { success: true };
     }),
 
@@ -1660,11 +1973,19 @@ export const raidPlanRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      const planId = await getRaidPlanIdForPlanCharacter(
+        ctx.db,
+        input.planCharacterId,
+      );
       await ctx.db
         .delete(raidPlanEncounterAASlots)
         .where(
           eq(raidPlanEncounterAASlots.planCharacterId, input.planCharacterId),
         );
+
+      if (planId) {
+        await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
+      }
 
       return { success: true };
     }),
@@ -1682,6 +2003,10 @@ export const raidPlanRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      const planId = await getRaidPlanIdForPlanCharacter(
+        ctx.db,
+        input.fromPlanCharacterId,
+      );
       // Get all encounter assignments for the source character that have positions
       const fromAssignments = await ctx.db
         .select()
@@ -1735,6 +2060,10 @@ export const raidPlanRouter = createTRPCRouter({
           .where(eq(raidPlanEncounterAssignments.id, assignment.id));
       }
 
+      if (planId) {
+        await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
+      }
+
       return { success: true, transferred: assignmentsWithPositions.length };
     }),
 
@@ -1749,6 +2078,10 @@ export const raidPlanRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      const planId = await getRaidPlanIdForPlanCharacter(
+        ctx.db,
+        input.planCharacterId,
+      );
       await ctx.db
         .update(raidPlanEncounterAssignments)
         .set({ groupNumber: null, position: null })
@@ -1758,6 +2091,10 @@ export const raidPlanRouter = createTRPCRouter({
             input.planCharacterId,
           ),
         );
+
+      if (planId) {
+        await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
+      }
 
       return { success: true };
     }),
@@ -1988,6 +2325,8 @@ export const raidPlanRouter = createTRPCRouter({
         }
       });
 
+      await touchRaidPlanActor(ctx.db, input.raidPlanId, ctx.session.user.id);
+
       return {
         encounters: encounterSummaries.map((e) => ({
           encounterId: e.encounterId,
@@ -2183,6 +2522,8 @@ export const raidPlanRouter = createTRPCRouter({
         }
       });
 
+      await touchRaidPlanActor(ctx.db, input.planId, ctx.session.user.id);
+
       return {
         added: toInsert.length,
         updated: charactersToUpdate.size,
@@ -2206,6 +2547,7 @@ export const raidPlanRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      const firstEncounterId = input.encounters[0]?.id;
       await ctx.db.transaction(async (tx) => {
         for (const enc of input.encounters) {
           const updates: { sortOrder: number; groupId?: string | null } = {
@@ -2220,6 +2562,16 @@ export const raidPlanRouter = createTRPCRouter({
             .where(eq(raidPlanEncounters.id, enc.id));
         }
       });
+
+      if (firstEncounterId) {
+        const planId = await getRaidPlanIdForEncounter(
+          ctx.db,
+          firstEncounterId,
+        );
+        if (planId) {
+          await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
+        }
+      }
 
       return { success: true };
     }),
@@ -2268,6 +2620,8 @@ export const raidPlanRouter = createTRPCRouter({
           sortOrder: raidPlanEncounterGroups.sortOrder,
         });
 
+      await touchRaidPlanActor(ctx.db, input.planId, ctx.session.user.id);
+
       return newGroup[0]!;
     }),
 
@@ -2282,10 +2636,18 @@ export const raidPlanRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      const planId = await getRaidPlanIdForEncounterGroup(
+        ctx.db,
+        input.groupId,
+      );
       await ctx.db
         .update(raidPlanEncounterGroups)
         .set({ groupName: input.groupName })
         .where(eq(raidPlanEncounterGroups.id, input.groupId));
+
+      if (planId) {
+        await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
+      }
 
       return { success: true };
     }),
@@ -2303,6 +2665,10 @@ export const raidPlanRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      const planId = await getRaidPlanIdForEncounterGroup(
+        ctx.db,
+        input.groupId,
+      );
       await ctx.db.transaction(async (tx) => {
         if (input.mode === "promote") {
           await tx
@@ -2319,6 +2685,10 @@ export const raidPlanRouter = createTRPCRouter({
           .delete(raidPlanEncounterGroups)
           .where(eq(raidPlanEncounterGroups.id, input.groupId));
       });
+
+      if (planId) {
+        await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
+      }
 
       return { success: true };
     }),
@@ -2345,6 +2715,8 @@ export const raidPlanRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      const firstGroupId = input.groups[0]?.id;
+      const firstEncounterId = input.encounters[0]?.id;
       await ctx.db.transaction(async (tx) => {
         for (const g of input.groups) {
           await tx
@@ -2359,6 +2731,16 @@ export const raidPlanRouter = createTRPCRouter({
             .where(eq(raidPlanEncounters.id, enc.id));
         }
       });
+
+      const planId = firstGroupId
+        ? await getRaidPlanIdForEncounterGroup(ctx.db, firstGroupId)
+        : firstEncounterId
+          ? await getRaidPlanIdForEncounter(ctx.db, firstEncounterId)
+          : null;
+
+      if (planId) {
+        await touchRaidPlanActor(ctx.db, planId, ctx.session.user.id);
+      }
 
       return { success: true };
     }),
@@ -2428,6 +2810,8 @@ export const raidPlanRouter = createTRPCRouter({
             );
         }
       });
+
+      await touchRaidPlanActor(ctx.db, input.planId, ctx.session.user.id);
 
       return { success: true };
     }),

--- a/src/server/db/models/raid-plan-schema.ts
+++ b/src/server/db/models/raid-plan-schema.ts
@@ -10,8 +10,14 @@ import {
   timestamp,
 } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
-import { IdPkAsUUID, DefaultTimestamps, CreatedBy } from "~/server/db/helpers";
+import {
+  IdPkAsUUID,
+  DefaultTimestamps,
+  CreatedBy,
+  UpdatedBy,
+} from "~/server/db/helpers";
 import { raids, characters } from "~/server/db/models/raid-schema";
+import { users } from "~/server/db/models/auth-schema";
 
 const tableCreator = pgTableCreator((name) => name);
 
@@ -154,6 +160,7 @@ export const raidPlans = tableCreator(
     isPublic: boolean("is_public").notNull().default(false),
     startAt: timestamp("start_at"),
     ...CreatedBy,
+    ...UpdatedBy,
     ...DefaultTimestamps,
   },
   (table) => ({
@@ -173,6 +180,7 @@ export const raidPlansRelations = relations(raidPlans, ({ one, many }) => ({
   encounterGroups: many(raidPlanEncounterGroups),
   encounters: many(raidPlanEncounters),
   defaultAASlots: many(raidPlanEncounterAASlots),
+  presence: many(raidPlanPresence),
 }));
 
 /**
@@ -395,6 +403,58 @@ export const raidPlanEncounterAASlotsRelations = relations(
     planCharacter: one(raidPlanCharacters, {
       fields: [raidPlanEncounterAASlots.planCharacterId],
       references: [raidPlanCharacters.id],
+    }),
+  }),
+);
+
+/**
+ * Ephemeral viewer/editor presence for a raid plan.
+ * One row per client session tab. Presence is considered active based on lastSeenAt.
+ */
+export const raidPlanPresence = tableCreator(
+  "raid_plan_presence",
+  {
+    ...IdPkAsUUID,
+    raidPlanId: uuid("raid_plan_id")
+      .notNull()
+      .references(() => raidPlans.id, { onDelete: "cascade" }),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    clientSessionId: varchar("client_session_id", { length: 128 }).notNull(),
+    mode: varchar("mode", { length: 16 }).notNull().default("viewing"),
+    lastSeenAt: timestamp("last_seen_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => ({
+    raidPlanIdIdx: index("raid_plan_presence__raid_plan_id_idx").on(
+      table.raidPlanId,
+    ),
+    userIdIdx: index("raid_plan_presence__user_id_idx").on(table.userId),
+    lastSeenAtIdx: index("raid_plan_presence__last_seen_at_idx").on(
+      table.lastSeenAt,
+    ),
+    sessionIdx: uniqueIndex("raid_plan_presence__plan_session_idx").on(
+      table.raidPlanId,
+      table.clientSessionId,
+    ),
+  }),
+);
+
+export const raidPlanPresenceRelations = relations(
+  raidPlanPresence,
+  ({ one }) => ({
+    raidPlan: one(raidPlans, {
+      fields: [raidPlanPresence.raidPlanId],
+      references: [raidPlans.id],
+    }),
+    user: one(users, {
+      fields: [raidPlanPresence.userId],
+      references: [users.id],
     }),
   }),
 );

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -65,6 +65,7 @@ export const {
   raidPlanEncounters,
   raidPlanEncounterAssignments,
   raidPlanEncounterAASlots,
+  raidPlanPresence,
 
   // Relations
   raidPlanTemplatesRelations,
@@ -76,6 +77,7 @@ export const {
   raidPlanEncountersRelations,
   raidPlanEncounterAssignmentsRelations,
   raidPlanEncounterAASlotsRelations,
+  raidPlanPresenceRelations,
 } = RaidPlanSchema;
 
 export const {


### PR DESCRIPTION
Adds clearer collaboration context to raid plans so people can see ownership, recent edits, and who is currently active before they step on each other.

### Features + updates

- shows who created a raid plan and who last edited it, with a relative last-updated timestamp in the planner header
- adds Vercel-safe live presence for raid planners, including active viewers and editors next to the sync indicator
- separates sync status from collaborator presence so the existing Live icon clearly represents polling, not shared editing

### Technical details

- adds _raid_plan.updated_by_ and a new _raid_plan_presence_ table, plus API support for creator/editor metadata and heartbeat-based presence
- uses polling plus periodic heartbeat writes instead of websockets, with presence reads at 15s and heartbeats at 30s
