### PR TITLE
feat(raid-planner): add last edited metadata to plan lists

### DIFF
--- a/src/components/raid-planner/past-plans-table.tsx
+++ b/src/components/raid-planner/past-plans-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { formatDistanceToNow } from "date-fns";
 import { Button } from "~/components/ui/button";
 import { ExternalLink } from "lucide-react";
 import Link from "next/link";
@@ -16,6 +17,12 @@ interface PastPlan {
   zoneId: string;
   createdAt: Date;
   startAt: Date | null;
+  lastModifiedAt: Date;
+  lastEditor: {
+    id: string;
+    name: string | null;
+    image: string | null;
+  } | null;
   raidHelperEventId: string;
 }
 
@@ -37,11 +44,14 @@ export function PastPlansTable({ plans }: PastPlansTableProps) {
       <table className="w-full caption-bottom text-sm">
         <thead className="sticky top-0 z-10 border-b bg-background [&_tr]:border-b">
           <tr className="border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted">
-            <th
-              colSpan={2}
-              className="h-10 px-2 text-left align-middle font-medium text-muted-foreground"
-            >
+            <th className="h-10 w-[1px] px-2 text-left align-middle font-medium text-muted-foreground">
+              <span className="sr-only">Action</span>
+            </th>
+            <th className="h-10 px-2 text-left align-middle font-medium text-muted-foreground">
               Plans ({plans.length})
+            </th>
+            <th className="hidden h-10 px-2 text-left align-middle font-medium text-muted-foreground lg:table-cell lg:w-[220px]">
+              Last Edited
             </th>
             <th className="hidden h-10 px-2 text-center align-middle font-medium text-muted-foreground md:table-cell md:w-[60px]">
               Link
@@ -57,6 +67,16 @@ export function PastPlansTable({ plans }: PastPlansTableProps) {
               dateStr = formatRaidDay(plan.startAt);
               timeStr = formatRaidTime(plan.startAt);
             }
+
+            const lastEditedText = plan.lastEditor?.name
+              ? `Last edited by ${plan.lastEditor.name} ${formatDistanceToNow(
+                  new Date(plan.lastModifiedAt),
+                  { addSuffix: true },
+                )}`
+              : `Last updated ${formatDistanceToNow(
+                  new Date(plan.lastModifiedAt),
+                  { addSuffix: true },
+                )}`;
 
             return (
               <tr
@@ -82,6 +102,14 @@ export function PastPlansTable({ plans }: PastPlansTableProps) {
                       {dateStr}
                       {timeStr ? ` • ${timeStr}` : ""}
                     </div>
+                    <div className="truncate text-xs font-normal text-muted-foreground lg:hidden">
+                      {lastEditedText}
+                    </div>
+                  </div>
+                </td>
+                <td className="hidden p-2 align-middle lg:table-cell">
+                  <div className="truncate text-xs font-normal text-muted-foreground">
+                    {lastEditedText}
                   </div>
                 </td>
                 <td className="hidden p-2 text-center align-middle md:table-cell [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]">

--- a/src/components/raid-planner/scheduled-events-table.tsx
+++ b/src/components/raid-planner/scheduled-events-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { formatDistanceToNow } from "date-fns";
 import { useState } from "react";
 import { Button } from "~/components/ui/button";
 import { ExternalLink, Loader2, Users } from "lucide-react";
@@ -32,7 +33,20 @@ interface ScheduledEvent {
 
 interface ScheduledEventsTableProps {
   events: ScheduledEvent[] | undefined;
-  existingPlans: Record<string, string> | undefined; // map eventId -> planId
+  existingPlans:
+    | Record<
+        string,
+        {
+          id: string;
+          lastModifiedAt: Date;
+          lastEditor: {
+            id: string;
+            name: string | null;
+            image: string | null;
+          } | null;
+        }
+      >
+    | undefined;
   onFindPlayers: (
     eventId: string,
     eventTitle: string,
@@ -61,11 +75,14 @@ export function ScheduledEventsTable({
       <table className="w-full caption-bottom text-sm">
         <thead className="sticky top-0 z-10 border-b bg-background [&_tr]:border-b">
           <tr className="border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted">
-            <th
-              colSpan={2}
-              className="h-10 w-[50%] px-2 text-left align-middle font-medium text-muted-foreground"
-            >
+            <th className="h-10 w-[1px] px-2 text-left align-middle font-medium text-muted-foreground">
+              <span className="sr-only">Action</span>
+            </th>
+            <th className="h-10 w-[50%] px-2 text-left align-middle font-medium text-muted-foreground">
               Events ({events.length})
+            </th>
+            <th className="hidden h-10 px-2 text-left align-middle font-medium text-muted-foreground lg:table-cell lg:w-[220px]">
+              Last Edited
             </th>
             <th className="h-10 w-[50%] px-2 text-left align-middle font-medium text-muted-foreground">
               Signups
@@ -80,7 +97,7 @@ export function ScheduledEventsTable({
             <EventRow
               key={event.id}
               event={event}
-              existingPlanId={existingPlans?.[event.id]}
+              existingPlan={existingPlans?.[event.id]}
               onFindPlayers={onFindPlayers}
               onSelect={() => onSelectEvent(event.id)}
             />
@@ -93,12 +110,20 @@ export function ScheduledEventsTable({
 
 function EventRow({
   event,
-  existingPlanId,
+  existingPlan,
   onFindPlayers,
   onSelect,
 }: {
   event: ScheduledEvent;
-  existingPlanId?: string;
+  existingPlan?: {
+    id: string;
+    lastModifiedAt: Date;
+    lastEditor: {
+      id: string;
+      name: string | null;
+      image: string | null;
+    } | null;
+  };
   onFindPlayers: (
     eventId: string,
     eventTitle: string,
@@ -157,13 +182,24 @@ function EventRow({
 
   const target = getRaidTarget(event.title, event.channelName);
   const colors = getSignupStatusColor(event.signUpCount ?? 0, target);
+  const lastEditedText = existingPlan
+    ? existingPlan.lastEditor?.name
+      ? `Last edited by ${existingPlan.lastEditor.name} ${formatDistanceToNow(
+          new Date(existingPlan.lastModifiedAt),
+          { addSuffix: true },
+        )}`
+      : `Last updated ${formatDistanceToNow(
+          new Date(existingPlan.lastModifiedAt),
+          { addSuffix: true },
+        )}`
+    : null;
 
   return (
     <tr className="group border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted">
       <td className="w-[1px] whitespace-nowrap p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]">
-        {existingPlanId ? (
+        {existingPlan ? (
           <Button variant="secondary" size="sm" className="w-20" asChild>
-            <Link href={`/raid-manager/raid-planner/${existingPlanId}`}>
+            <Link href={`/raid-manager/raid-planner/${existingPlan.id}`}>
               View Plan
             </Link>
           </Button>
@@ -184,7 +220,19 @@ function EventRow({
           <div className="truncate text-[11px] uppercase tracking-[0.12em] text-muted-foreground">
             {formattedDate} {formattedTime ? `• ${formattedTime}` : ""}
           </div>
+          {lastEditedText ? (
+            <div className="truncate text-xs font-normal text-muted-foreground lg:hidden">
+              {lastEditedText}
+            </div>
+          ) : null}
         </div>
+      </td>
+      <td className="hidden p-2 align-middle lg:table-cell">
+        {lastEditedText ? (
+          <div className="truncate text-xs font-normal text-muted-foreground">
+            {lastEditedText}
+          </div>
+        ) : null}
       </td>
       <td className="w-[50%] p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]">
         <div className="flex items-center justify-start gap-3">

--- a/src/server/api/routers/raid-plan.ts
+++ b/src/server/api/routers/raid-plan.ts
@@ -137,14 +137,39 @@ export const raidPlanRouter = createTRPCRouter({
         .select({
           id: raidPlans.id,
           raidHelperEventId: raidPlans.raidHelperEventId,
+          lastModifiedAt: sql<Date>`COALESCE(${raidPlans.updatedAt}, ${raidPlans.createdAt})`,
+          lastEditor: {
+            id: lastEditorUsers.id,
+            name: lastEditorUsers.name,
+            image: lastEditorUsers.image,
+          },
         })
         .from(raidPlans)
+        .leftJoin(
+          lastEditorUsers,
+          eq(lastEditorUsers.id, raidPlans.updatedById),
+        )
         .where(inArray(raidPlans.raidHelperEventId, input.raidHelperEventIds));
 
-      // Return as a map: raidHelperEventId -> planId
-      const result: Record<string, string> = {};
+      // Return as a map: raidHelperEventId -> existing plan summary
+      const result: Record<
+        string,
+        {
+          id: string;
+          lastModifiedAt: Date;
+          lastEditor: {
+            id: string;
+            name: string | null;
+            image: string | null;
+          } | null;
+        }
+      > = {};
       for (const plan of plans) {
-        result[plan.raidHelperEventId] = plan.id;
+        result[plan.raidHelperEventId] = {
+          id: plan.id,
+          lastModifiedAt: plan.lastModifiedAt,
+          lastEditor: normalizeUserIdentity(plan.lastEditor),
+        };
       }
       return result;
     }),
@@ -175,13 +200,26 @@ export const raidPlanRouter = createTRPCRouter({
           raidHelperEventId: raidPlans.raidHelperEventId,
           createdAt: raidPlans.createdAt,
           startAt: raidPlans.startAt,
+          lastModifiedAt: sql<Date>`COALESCE(${raidPlans.updatedAt}, ${raidPlans.createdAt})`,
+          lastEditor: {
+            id: lastEditorUsers.id,
+            name: lastEditorUsers.name,
+            image: lastEditorUsers.image,
+          },
         })
         .from(raidPlans)
+        .leftJoin(
+          lastEditorUsers,
+          eq(lastEditorUsers.id, raidPlans.updatedById),
+        )
         .where(whereClause)
         .orderBy(desc(raidPlans.startAt), desc(raidPlans.createdAt))
         .limit(input.limit);
 
-      return plans;
+      return plans.map((plan) => ({
+        ...plan,
+        lastEditor: normalizeUserIdentity(plan.lastEditor),
+      }));
     }),
 
   /**


### PR DESCRIPTION
Adds "Last Edited" information to the raid plan lists, showing when a plan was last updated and by whom.

### Features + updates

- Added "Last Edited" column to the _Past Plans_ and _Scheduled Events_ tables.
- Displayed last editor's name and avatar with relative time (e.g., "2 hours ago").

### Technical details

- Updated _getPastPlans_ and _getScheduledEvents_ tRPC procedures to fetch editor metadata.
- Implemented _normalizeUserIdentity_ for consistent user data handling in the tRPC router.
- Added _lastModifiedAt_ and _lastEditor_ fields to the plan list response schemas.