### PR TITLE
Character Assignment Summary Panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# superpowers brainstorm/session artifacts
+.superpowers/
+
 # dependencies
 /node_modules
 /.pnp

--- a/docs/superpowers/plans/2026-04-27-character-assignment-summary.md
+++ b/docs/superpowers/plans/2026-04-27-character-assignment-summary.md
@@ -1,0 +1,571 @@
+# Character Assignment Summary Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a character-specific assignment summary panel to the public raid plan view (`/raid-plans/:id`) that appears when a "View as" character is selected, showing their AA assignments across all encounters at a glance.
+
+**Architecture:** A new pure utility `extractCharacterLines` is added to `src/lib/aa-template.ts` — it splits a template by newlines and returns only lines containing the character's assigned slots. A new `CharacterSummaryPanel` component renders a summary sentence and a collapsible responsive grid of per-encounter AA blocks, reusing `AATemplateRenderer` for rendering. `RaidPlanPublicView` derives `CharacterEncounterSummary[]` via a `useMemo` from already-fetched plan data and wires `onEncounterClick` to `setActiveTab`. No new API calls or server changes.
+
+**Tech Stack:** React, Tailwind CSS, shadcn/ui components, Vitest (new, for unit tests on the utility function)
+
+---
+
+## File Map
+
+| File                                                      | Action | Responsibility                                                  |
+| --------------------------------------------------------- | ------ | --------------------------------------------------------------- |
+| `src/lib/aa-template.ts`                                  | Modify | Add `extractCharacterLines` export                              |
+| `src/lib/__tests__/aa-template.test.ts`                   | Create | Unit tests for `extractCharacterLines`                          |
+| `src/components/raid-planner/character-summary-panel.tsx` | Create | Summary panel component + `CharacterEncounterSummary` interface |
+| `src/components/raid-planner/raid-plan-public-view.tsx`   | Modify | `encounterSummaries` memo + render panel                        |
+| `vitest.config.ts`                                        | Create | Vitest configuration                                            |
+| `package.json`                                            | Modify | Add `test` and `test:watch` scripts                             |
+
+---
+
+## Task 0: Set up Vitest
+
+**Files:**
+
+- Create: `vitest.config.ts`
+- Modify: `package.json`
+
+- [ ] **Step 1: Install Vitest and path-alias plugin**
+
+```bash
+pnpm add -D vitest vite-tsconfig-paths
+```
+
+Expected: packages added to `devDependencies` in `package.json`.
+
+- [ ] **Step 2: Create `vitest.config.ts`**
+
+```typescript
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: "node",
+  },
+});
+```
+
+- [ ] **Step 3: Add test scripts to `package.json`**
+
+In the `"scripts"` block, add after the existing scripts:
+
+```json
+"test": "vitest run",
+"test:watch": "vitest"
+```
+
+- [ ] **Step 4: Verify Vitest runs**
+
+```bash
+pnpm test
+```
+
+Expected output: `No test files found` (or similar — no failures, just no tests yet).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vitest.config.ts package.json pnpm-lock.yaml
+git commit -m "chore(test): add vitest for unit tests"
+```
+
+---
+
+## Task 1: Add `extractCharacterLines` utility (TDD)
+
+**Files:**
+
+- Create: `src/lib/__tests__/aa-template.test.ts`
+- Modify: `src/lib/aa-template.ts`
+
+- [ ] **Step 1: Create the test file with failing tests**
+
+Create `src/lib/__tests__/aa-template.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { extractCharacterLines } from "../aa-template";
+
+describe("extractCharacterLines", () => {
+  it("returns lines containing {assign:SlotName}", () => {
+    const template = "Line 1\n{skull} Tank: {assign:MainTank}\nLine 3";
+    expect(extractCharacterLines(template, ["MainTank"])).toEqual([
+      "{skull} Tank: {assign:MainTank}",
+    ]);
+  });
+
+  it("returns lines containing {ref:SlotName}", () => {
+    const template =
+      "{assign:MainTank} Rend\nRef line: {ref:MainTank}\nOther line";
+    expect(extractCharacterLines(template, ["MainTank"])).toEqual([
+      "{assign:MainTank} Rend",
+      "Ref line: {ref:MainTank}",
+    ]);
+  });
+
+  it("matches case-insensitively", () => {
+    const template = "Tank: {assign:MAINTANK}";
+    expect(extractCharacterLines(template, ["maintank"])).toEqual([
+      "Tank: {assign:MAINTANK}",
+    ]);
+  });
+
+  it("matches slots with modifiers like {assign:SlotName:4}", () => {
+    const template = "Tank: {assign:MainTank:4:nocolor}";
+    expect(extractCharacterLines(template, ["MainTank"])).toEqual([
+      "Tank: {assign:MainTank:4:nocolor}",
+    ]);
+  });
+
+  it("matches slots with ref modifier {ref:SlotName:nocolor}", () => {
+    const template = "Ref: {ref:MainTank:nocolor}";
+    expect(extractCharacterLines(template, ["MainTank"])).toEqual([
+      "Ref: {ref:MainTank:nocolor}",
+    ]);
+  });
+
+  it("returns empty array when template is empty", () => {
+    expect(extractCharacterLines("", ["MainTank"])).toEqual([]);
+  });
+
+  it("returns empty array when slotNames is empty", () => {
+    expect(extractCharacterLines("Tank: {assign:MainTank}", [])).toEqual([]);
+  });
+
+  it("only returns lines containing the specified slots", () => {
+    const template = "MT: {assign:MainTank}\nOT: {assign:OffTank}";
+    expect(extractCharacterLines(template, ["MainTank"])).toEqual([
+      "MT: {assign:MainTank}",
+    ]);
+  });
+
+  it("returns a line containing any of multiple specified slots", () => {
+    const template =
+      "{assign:MainTank} and {assign:OffTank} on same line\nUnrelated line";
+    expect(extractCharacterLines(template, ["MainTank", "OffTank"])).toEqual([
+      "{assign:MainTank} and {assign:OffTank} on same line",
+    ]);
+  });
+
+  it("does not return lines with similar but non-matching slot names", () => {
+    const template = "MT: {assign:MainTankBackup}\nOT: {assign:MainTank}";
+    expect(extractCharacterLines(template, ["MainTank"])).toEqual([
+      "OT: {assign:MainTank}",
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+pnpm test
+```
+
+Expected: all tests in `aa-template.test.ts` fail with `extractCharacterLines is not a function` or similar.
+
+- [ ] **Step 3: Add `extractCharacterLines` to `src/lib/aa-template.ts`**
+
+Append the following export after the existing `getSlotDefinitions` function at the bottom of the file:
+
+```typescript
+/**
+ * Extract template lines that contain an {assign:} or {ref:} tag for any of
+ * the given slot names. Used to build the per-character assignment summary.
+ */
+export function extractCharacterLines(
+  template: string,
+  slotNames: string[],
+): string[] {
+  if (!template || slotNames.length === 0) return [];
+
+  const lowerNames = slotNames.map((n) => n.toLowerCase());
+
+  return template.split("\n").filter((line) => {
+    const lower = line.toLowerCase();
+    return lowerNames.some(
+      (name) =>
+        lower.includes(`{assign:${name}}`) ||
+        lower.includes(`{assign:${name}:`) ||
+        lower.includes(`{ref:${name}}`) ||
+        lower.includes(`{ref:${name}:`),
+    );
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+pnpm test
+```
+
+Expected: all 10 tests in `aa-template.test.ts` pass. Zero failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/aa-template.ts src/lib/__tests__/aa-template.test.ts
+git commit -m "feat(raid-plan): add extractCharacterLines utility"
+```
+
+---
+
+## Task 2: Create `CharacterSummaryPanel` component
+
+**Files:**
+
+- Create: `src/components/raid-planner/character-summary-panel.tsx`
+
+- [ ] **Step 1: Create the component file**
+
+Create `src/components/raid-planner/character-summary-panel.tsx`:
+
+```typescript
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronUp, ChevronRight } from "lucide-react";
+import { ClassIcon } from "~/components/ui/class-icon";
+import { AA_CLASS_COLORS } from "~/lib/aa-formatting";
+import { AATemplateRenderer } from "./aa-template-renderer";
+import type { RaidPlanCharacter, AASlotAssignment } from "./types";
+
+export interface CharacterEncounterSummary {
+  encounterId: string | "default";
+  encounterName: string;
+  slotNames: string[];
+  /** extractCharacterLines(fullTemplate, slotNames).join('\n') */
+  template: string;
+  /** Assignments filtered to this encounter context */
+  slotAssignments: AASlotAssignment[];
+  /** planId when encounterId === "default"; encounter UUID otherwise */
+  contextId: string;
+}
+
+interface CharacterSummaryPanelProps {
+  viewAsCharacter: { name: string; class: string | null };
+  encounterSummaries: CharacterEncounterSummary[];
+  allCharacters: RaidPlanCharacter[];
+  userCharacterIds: number[];
+  onEncounterClick: (encounterId: string) => void;
+}
+
+export function CharacterSummaryPanel({
+  viewAsCharacter,
+  encounterSummaries,
+  allCharacters,
+  userCharacterIds,
+  onEncounterClick,
+}: CharacterSummaryPanelProps) {
+  const [showDetails, setShowDetails] = useState(true);
+
+  const classColor = viewAsCharacter.class
+    ? (AA_CLASS_COLORS[
+        viewAsCharacter.class.toLowerCase().replace(/\s+/g, "")
+      ] ?? undefined)
+    : undefined;
+
+  const summaryEncounters = encounterSummaries.slice(0, 3);
+  const remainingCount = encounterSummaries.length - 3;
+
+  return (
+    <div className="mb-4 overflow-hidden rounded-lg border border-border bg-card">
+      {/* Summary line */}
+      <div className="flex items-start justify-between gap-3 p-3">
+        {encounterSummaries.length === 0 ? (
+          <p className="text-sm italic text-muted-foreground">
+            No assignments found for{" "}
+            <span className="font-semibold">{viewAsCharacter.name}</span> —
+            show up, stay alive, and try not to stand in the bad. GLHF.
+          </p>
+        ) : (
+          <p className="flex-1 text-sm leading-relaxed">
+            {viewAsCharacter.class && (
+              <ClassIcon
+                characterClass={viewAsCharacter.class}
+                px={16}
+                className="mr-1 inline-block align-middle"
+              />
+            )}
+            <span
+              className="font-bold"
+              style={classColor ? { color: classColor } : undefined}
+            >
+              {viewAsCharacter.name}
+            </span>{" "}
+            has assignments in{" "}
+            {summaryEncounters.map((s, i) => (
+              <span key={s.encounterId}>
+                <span className="font-semibold text-foreground">
+                  {s.encounterName}
+                </span>{" "}
+                (
+                {s.slotNames.map((name, j) => (
+                  <span key={name}>
+                    <span className="inline-block rounded border border-purple-500/25 bg-purple-500/10 px-1 text-xs font-medium text-purple-300">
+                      {name}
+                    </span>
+                    {j < s.slotNames.length - 1 ? " " : ""}
+                  </span>
+                ))}
+                ){i < summaryEncounters.length - 1 ? ", " : ""}
+              </span>
+            ))}
+            {remainingCount > 0 &&
+              `, and ${remainingCount} more encounter${remainingCount !== 1 ? "s" : ""}.`}
+          </p>
+        )}
+        {encounterSummaries.length > 0 && (
+          <button
+            onClick={() => setShowDetails((v) => !v)}
+            className="flex shrink-0 items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:border-muted-foreground hover:text-foreground"
+          >
+            {showDetails ? (
+              <ChevronUp className="h-3 w-3" />
+            ) : (
+              <ChevronDown className="h-3 w-3" />
+            )}
+            {showDetails ? "Hide details" : "Show details"}
+          </button>
+        )}
+      </div>
+
+      {/* Encounter grid */}
+      {showDetails && encounterSummaries.length > 0 && (
+        <div className="border-t border-border p-3">
+          <div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
+            {encounterSummaries.map((summary) => (
+              <div
+                key={summary.encounterId}
+                onClick={() => onEncounterClick(summary.encounterId)}
+                className="cursor-pointer overflow-hidden rounded-md border border-border bg-muted/30 transition-colors hover:border-muted-foreground/50 hover:bg-muted/50"
+              >
+                <div className="flex items-center gap-2 border-b border-border px-3 py-1.5">
+                  <div className="h-3 w-0.5 shrink-0 rounded-full bg-purple-400" />
+                  <span className="flex-1 truncate text-xs font-semibold text-foreground">
+                    {summary.encounterName}
+                  </span>
+                  <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+                </div>
+                <div className="p-2">
+                  <AATemplateRenderer
+                    template={summary.template}
+                    encounterId={
+                      summary.encounterId !== "default"
+                        ? summary.contextId
+                        : undefined
+                    }
+                    raidPlanId={
+                      summary.encounterId === "default"
+                        ? summary.contextId
+                        : undefined
+                    }
+                    characters={allCharacters}
+                    slotAssignments={summary.slotAssignments}
+                    readOnly
+                    hideUnassigned
+                    skipDndContext
+                    userCharacterIds={userCharacterIds}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify it type-checks**
+
+```bash
+pnpm typecheck
+```
+
+Expected: no errors in `character-summary-panel.tsx`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/raid-planner/character-summary-panel.tsx
+git commit -m "feat(raid-plan): add CharacterSummaryPanel component"
+```
+
+---
+
+## Task 3: Wire up integration in `RaidPlanPublicView`
+
+**Files:**
+
+- Modify: `src/components/raid-planner/raid-plan-public-view.tsx`
+
+- [ ] **Step 1: Add imports**
+
+At the top of `src/components/raid-planner/raid-plan-public-view.tsx`, add these two imports alongside the existing ones:
+
+```typescript
+import { extractCharacterLines } from "~/lib/aa-template";
+import {
+  CharacterSummaryPanel,
+  type CharacterEncounterSummary,
+} from "./character-summary-panel";
+```
+
+- [ ] **Step 2: Add the `encounterSummaries` memo**
+
+In `RaidPlanPublicView`, add this `useMemo` directly after the existing `assignmentLabelsMap` memo (around line 145):
+
+```typescript
+const encounterSummaries = useMemo((): CharacterEncounterSummary[] => {
+  if (!plan || assignmentLabelsMap.size === 0) return [];
+
+  const summaries: CharacterEncounterSummary[] = [];
+
+  // Default/Trash
+  const defaultSlotNames = assignmentLabelsMap.get("default");
+  if (defaultSlotNames?.length && plan.useDefaultAA && plan.defaultAATemplate) {
+    const lines = extractCharacterLines(
+      plan.defaultAATemplate,
+      defaultSlotNames,
+    );
+    if (lines.length > 0) {
+      summaries.push({
+        encounterId: "default",
+        encounterName: "Default/Trash",
+        slotNames: defaultSlotNames,
+        template: lines.join("\n"),
+        slotAssignments: plan.aaSlotAssignments.filter(
+          (a) => a.raidPlanId === planId && a.encounterId === null,
+        ),
+        contextId: planId,
+      });
+    }
+  }
+
+  // Encounter-specific (sorted by sortOrder)
+  const sortedEncounters = [...plan.encounters].sort(
+    (a, b) => a.sortOrder - b.sortOrder,
+  );
+  for (const encounter of sortedEncounters) {
+    const slotNames = assignmentLabelsMap.get(encounter.id);
+    if (!slotNames?.length || !encounter.useCustomAA || !encounter.aaTemplate)
+      continue;
+
+    const lines = extractCharacterLines(encounter.aaTemplate, slotNames);
+    if (lines.length === 0) continue;
+
+    summaries.push({
+      encounterId: encounter.id,
+      encounterName: encounter.encounterName,
+      slotNames,
+      template: lines.join("\n"),
+      slotAssignments: plan.aaSlotAssignments.filter(
+        (a) => a.encounterId === encounter.id,
+      ),
+      contextId: encounter.id,
+    });
+  }
+
+  return summaries;
+}, [plan, planId, assignmentLabelsMap]);
+```
+
+- [ ] **Step 3: Render the panel**
+
+In the JSX of `RaidPlanPublicView`, locate the `<Separator className="my-2" />` line (around line 288). Insert the panel immediately after it, before `<Tabs ...>`:
+
+```tsx
+<Separator className="my-2" />
+
+{viewAsCharacterId !== null && viewAsCharacter && (
+  <CharacterSummaryPanel
+    viewAsCharacter={viewAsCharacter}
+    encounterSummaries={encounterSummaries}
+    allCharacters={plan.characters as RaidPlanCharacter[]}
+    userCharacterIds={userCharacterIds}
+    onEncounterClick={setActiveTab}
+  />
+)}
+
+<Tabs value={activeTab} onValueChange={setActiveTab}>
+```
+
+- [ ] **Step 4: Type-check the full file**
+
+```bash
+pnpm typecheck
+```
+
+Expected: no errors. If `viewAsCharacter.class` causes a type mismatch on `ClassIcon` (which expects `string` not `string | null`), the null guard inside `CharacterSummaryPanel` already handles this — no change needed in the public view.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/raid-planner/raid-plan-public-view.tsx
+git commit -m "feat(raid-plan): wire up character assignment summary panel"
+```
+
+---
+
+## Task 4: Manual verification
+
+- [ ] **Step 1: Start the dev server**
+
+```bash
+pnpm dev
+```
+
+- [ ] **Step 2: Open a public raid plan that has AA templates configured**
+
+Navigate to `/raid-plans/<any-public-plan-id>`. You can find one via `/raid-plans`.
+
+- [ ] **Step 3: Verify the panel does NOT appear before selecting a character**
+
+The area between the separator and the encounter tabs should be empty.
+
+- [ ] **Step 4: Select a character using the "View as" selector**
+
+Pick a character that has AA assignments in at least one encounter. The panel should appear below the separator showing the summary sentence with class icon, class-colored name, encounter names, and role pills.
+
+- [ ] **Step 5: Verify the summary line truncation**
+
+If the character has assignments in more than 3 encounters, only 3 encounter names appear inline and "and N more encounters." appears at the end.
+
+- [ ] **Step 6: Verify the details grid**
+
+The details section should show a responsive grid of encounter blocks (3-col on wide screens). Each block has the encounter name header with a purple accent bar and the extracted AA lines with the character's name highlighted.
+
+- [ ] **Step 7: Verify clicking an encounter block switches the active tab**
+
+Click an encounter block in the summary. The encounter sidebar and main AA/groups view below should switch to that encounter.
+
+- [ ] **Step 8: Verify Hide/Show details toggle**
+
+Click "Hide details" — the grid collapses. Click "Show details" — it expands.
+
+- [ ] **Step 9: Verify the GLHF state**
+
+Select a character who is on the roster but has no AA assignments anywhere. The panel should show the "No assignments" italic message instead of the summary sentence and grid.
+
+- [ ] **Step 10: Run full checks and final commit**
+
+```bash
+pnpm check
+```
+
+Expected: no lint or type errors. If any formatting issues, run `pnpm format:write` first.
+
+```bash
+git add -A
+git commit -m "feat(raid-plan): character assignment summary panel"
+```

--- a/docs/superpowers/specs/2026-04-27-character-assignment-summary-design.md
+++ b/docs/superpowers/specs/2026-04-27-character-assignment-summary-design.md
@@ -34,18 +34,20 @@ The panel renders between the `<Separator>` and the `<Tabs>` block in `RaidPlanP
 - Character name is class-colored and bold.
 - Encounter names are white and bold.
 - Slot names render as small purple-tinted role pills.
-- First 3 encounters shown inline; when there are more than 3, the remainder is collapsed into a muted italic "and N more encounters." tail. When there are 3 or fewer, no tail is shown.
+- First 3 encounters shown inline; when there are more than 3, the remainder is collapsed into an "and N more encounters." tail (normal weight, not muted or italic). When there are 3 or fewer, no tail is shown.
 - Default/Trash is included if the character has assignments there; it appears as "Default/Trash" and sorts first.
 
 ### Collapsible details
 
 - A "Hide details / Show details" toggle button sits at the top-right of the panel.
 - Details are **expanded by default**.
-- Details section contains one block per encounter (same order as the summary line: Default/Trash first, then by encounter `sortOrder`).
+- Details section lays out encounter blocks in a responsive grid: 3 columns on `lg`, 2 columns on `md`, 1 column on smaller screens.
 - Each block shows:
-  - The encounter name as a small header with a purple left-border accent.
+  - The encounter name as a small clickable header with a purple left-border accent. Clicking it sets `activeTab` to that encounter's ID (switching the encounter view below). Default/Trash sets `activeTab` to `"default"`.
   - A monospace AA block containing only the template lines relevant to the character (see Line Extraction below), rendered via the existing `AATemplateRenderer` in `readOnly` + `hideUnassigned` mode, with `userCharacterIds` passed for highlighting.
   - The character's name is highlighted inside the AA block with a purple-tinted background badge.
+  - The entire block has a hover state (subtle border brightening) to indicate it's clickable.
+- Blocks are ordered: Default/Trash first, then by encounter `sortOrder`.
 
 ### No-assignments state
 
@@ -97,6 +99,7 @@ interface CharacterSummaryPanelProps {
   encounterSummaries: CharacterEncounterSummary[];
   allCharacters: RaidPlanCharacter[];
   userCharacterIds: number[];
+  onEncounterClick: (encounterId: string) => void; // switches active tab in parent
 }
 ```
 

--- a/docs/superpowers/specs/2026-04-27-character-assignment-summary-design.md
+++ b/docs/superpowers/specs/2026-04-27-character-assignment-summary-design.md
@@ -1,0 +1,136 @@
+# Character Assignment Summary Panel
+
+**Date:** 2026-04-27
+**Status:** Approved
+
+## Overview
+
+When a user views a public raid plan (`/raid-plans/:id`) with a character selected via the "View as" selector, show a character-specific assignment summary panel. The panel gives the selected character a quick overview of every encounter where they have an AA assignment, including the full template line(s) where they appear — so they can see context, not just a slot name.
+
+## Goals
+
+- Give raiders a "what am I doing tonight?" at-a-glance view without clicking through every encounter tab.
+- Surface the full AA line (not just the slot name) so role context is clear.
+- Zero new API calls — all data is already returned by `getPublicById`.
+
+## Non-Goals
+
+- No changes to the encounter sidebar, AA panel, or groups grid.
+- No server-side changes.
+- No support on the edit view (`/raid-manager/raid-planner/:id`) — public view only for now.
+
+## UI Behavior
+
+### Placement
+
+The panel renders between the `<Separator>` and the `<Tabs>` block in `RaidPlanPublicView`, full-width. It is only rendered when `viewAsCharacterId !== null` and `viewAsCharacter` has loaded.
+
+### Summary line
+
+```
+<ClassIcon> CharacterName has assignments in EncounterA (RoleX, RoleY), EncounterB (RoleZ), EncounterC (RoleW), and N more encounters.
+```
+
+- Character name is class-colored and bold.
+- Encounter names are white and bold.
+- Slot names render as small purple-tinted role pills.
+- First 3 encounters shown inline; when there are more than 3, the remainder is collapsed into a muted italic "and N more encounters." tail. When there are 3 or fewer, no tail is shown.
+- Default/Trash is included if the character has assignments there; it appears as "Default/Trash" and sorts first.
+
+### Collapsible details
+
+- A "Hide details / Show details" toggle button sits at the top-right of the panel.
+- Details are **expanded by default**.
+- Details section contains one block per encounter (same order as the summary line: Default/Trash first, then by encounter `sortOrder`).
+- Each block shows:
+  - The encounter name as a small header with a purple left-border accent.
+  - A monospace AA block containing only the template lines relevant to the character (see Line Extraction below), rendered via the existing `AATemplateRenderer` in `readOnly` + `hideUnassigned` mode, with `userCharacterIds` passed for highlighting.
+  - The character's name is highlighted inside the AA block with a purple-tinted background badge.
+
+### No-assignments state
+
+If `encounterSummaries` is empty (character is on the roster but has no AA assignments anywhere), the panel shows a muted, lightly humorous banner in place of the summary line. Something like: _"No assignments detected. Show up, stay alive, and maybe they'll notice. GLHF."_
+
+## Data Shape
+
+```typescript
+interface CharacterEncounterSummary {
+  encounterId: string | "default";
+  encounterName: string; // "Default/Trash" or the encounter's encounterName
+  slotNames: string[]; // slot names the character is assigned to, for pills
+  template: string; // extractCharacterLines(fullTemplate, slotNames).join('\n')
+  slotAssignments: AASlotAssignment[]; // filtered to this encounter context (by encounterId or raidPlanId)
+}
+```
+
+Derived client-side in a `useMemo` in `RaidPlanPublicView`, from existing `plan` data + `userCharacterIds`.
+
+## New Utility: `extractCharacterLines`
+
+Added to `src/lib/aa-template.ts`.
+
+```typescript
+export function extractCharacterLines(
+  template: string,
+  slotNames: string[], // slots this character is assigned to
+): string[]; // lines containing at least one of those slots
+```
+
+**Logic:**
+
+1. Split `template` by `\n`.
+2. Build a set of lowercased slot names.
+3. For each line, check if the lowercased line contains `{assign:slotname}` or `{ref:slotname}` for any slot in the set.
+4. Return matching lines.
+
+Both `{assign:}` and `{ref:}` tags are checked so that mirrored slot references are captured.
+
+## New Component: `CharacterSummaryPanel`
+
+**File:** `src/components/raid-planner/character-summary-panel.tsx`
+
+**Props:**
+
+```typescript
+interface CharacterSummaryPanelProps {
+  viewAsCharacter: { name: string; class: string | null };
+  encounterSummaries: CharacterEncounterSummary[];
+  allCharacters: RaidPlanCharacter[];
+  userCharacterIds: number[];
+}
+```
+
+**Internal state:** `const [showDetails, setShowDetails] = useState(true)`
+
+**Rendering:**
+
+- GLHF banner when `encounterSummaries.length === 0`.
+- Otherwise: summary line + toggle + collapsible details section.
+- Each encounter block uses `AATemplateRenderer` with `template = summary.template` (the extracted lines joined by `\n`), `slotAssignments = summary.slotAssignments`, `readOnly`, `hideUnassigned`, `skipDndContext`, `userCharacterIds`. The `encounterId` / `raidPlanId` prop is set based on whether `summary.encounterId` is `"default"` or an encounter UUID.
+
+## Integration
+
+In `raid-plan-public-view.tsx`:
+
+1. Add a `useMemo` for `encounterSummaries` (derived from `assignmentLabelsMap`, `plan.encounters`, `plan.defaultAATemplate`, `plan.aaSlotAssignments`).
+2. Render `<CharacterSummaryPanel>` between `<Separator>` and `<Tabs>`, gated on `viewAsCharacterId !== null && !!viewAsCharacter`.
+
+## Edge Cases
+
+| Case                                                  | Behavior                                                         |
+| ----------------------------------------------------- | ---------------------------------------------------------------- |
+| Character has no AA assignments anywhere              | GLHF banner                                                      |
+| Default/Trash has assignments                         | Included as first entry labeled "Default/Trash"                  |
+| Encounter has AA enabled but character isn't assigned | Encounter not listed                                             |
+| Character assigned via `{ref:}` tag only              | Line is still extracted (ref check in `extractCharacterLines`)   |
+| Character is an alt mapped to a primary               | `userCharacterIds` includes alt IDs — existing logic covers this |
+| Encounter AA is disabled (`useCustomAA = false`)      | `encounter.aaTemplate` is null — no entry for that encounter     |
+| Plan-level AA is disabled (`useDefaultAA = false`)    | `plan.defaultAATemplate` ignored — no Default/Trash entry        |
+
+## Files Changed
+
+| File                                                      | Change                                       |
+| --------------------------------------------------------- | -------------------------------------------- |
+| `src/lib/aa-template.ts`                                  | Add `extractCharacterLines()` export         |
+| `src/components/raid-planner/character-summary-panel.tsx` | New component                                |
+| `src/components/raid-planner/raid-plan-public-view.tsx`   | Add `encounterSummaries` memo + render panel |

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "prepare": "husky",
     "preview": "next build && next start",
     "start": "next start",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "postbuild": "drizzle-kit migrate"
   },
@@ -96,7 +98,9 @@
     "prettier": "^3.3.2",
     "prettier-plugin-tailwindcss": "^0.6.14",
     "tailwindcss": "^3.4.3",
-    "typescript": "^5.5.3"
+    "typescript": "^5.5.3",
+    "vite-tsconfig-paths": "^6.1.1",
+    "vitest": "^4.1.5"
   },
   "ct3aMetadata": {
     "initVersion": "7.38.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,12 @@ importers:
       typescript:
         specifier: ^5.5.3
         version: 5.9.2
+      vite-tsconfig-paths:
+        specifier: ^6.1.1
+        version: 6.1.1(typescript@5.9.2)(vite@8.0.10(@types/node@22.18.6)(esbuild@0.25.10)(jiti@1.21.7)(yaml@2.8.1))
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.18.6)(vite@8.0.10(@types/node@22.18.6)(esbuild@0.25.10)(jiti@1.21.7)(yaml@2.8.1))
 
 packages:
   "@alloc/quick-lru@5.2.0":
@@ -321,10 +327,22 @@ packages:
         integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==,
       }
 
+  "@emnapi/core@1.10.0":
+    resolution:
+      {
+        integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==,
+      }
+
   "@emnapi/core@1.5.0":
     resolution:
       {
         integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==,
+      }
+
+  "@emnapi/runtime@1.10.0":
+    resolution:
+      {
+        integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==,
       }
 
   "@emnapi/runtime@1.5.0":
@@ -337,6 +355,12 @@ packages:
     resolution:
       {
         integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==,
+      }
+
+  "@emnapi/wasi-threads@1.2.1":
+    resolution:
+      {
+        integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
       }
 
   "@esbuild-kit/core-utils@3.3.2":
@@ -1113,6 +1137,15 @@ packages:
         integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==,
       }
 
+  "@napi-rs/wasm-runtime@1.1.4":
+    resolution:
+      {
+        integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==,
+      }
+    peerDependencies:
+      "@emnapi/core": ^1.7.1
+      "@emnapi/runtime": ^1.7.1
+
   "@next/env@15.0.7":
     resolution:
       {
@@ -1335,6 +1368,12 @@ packages:
         integrity: sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==,
       }
     engines: { node: ">=14" }
+
+  "@oxc-project/types@0.127.0":
+    resolution:
+      {
+        integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==,
+      }
 
   "@panva/hkdf@1.2.1":
     resolution:
@@ -2168,6 +2207,146 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  "@rolldown/binding-android-arm64@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [android]
+
+  "@rolldown/binding-darwin-arm64@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@rolldown/binding-darwin-x64@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [darwin]
+
+  "@rolldown/binding-freebsd-x64@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+
+  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+
+  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ppc64]
+    os: [linux]
+
+  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [s390x]
+    os: [linux]
+
+  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+
+  "@rolldown/binding-linux-x64-musl@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+
+  "@rolldown/binding-openharmony-arm64@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@rolldown/binding-wasm32-wasi@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [wasm32]
+
+  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [win32]
+
+  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [win32]
+
+  "@rolldown/pluginutils@1.0.0-rc.17":
+    resolution:
+      {
+        integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==,
+      }
+
   "@rtsao/scc@1.1.0":
     resolution:
       {
@@ -2178,6 +2357,12 @@ packages:
     resolution:
       {
         integrity: sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==,
+      }
+
+  "@standard-schema/spec@1.1.0":
+    resolution:
+      {
+        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
       }
 
   "@swc/counter@0.1.3":
@@ -2282,10 +2467,22 @@ packages:
         integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==,
       }
 
+  "@types/chai@5.2.3":
+    resolution:
+      {
+        integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
+      }
+
   "@types/cookie@0.6.0":
     resolution:
       {
         integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==,
+      }
+
+  "@types/deep-eql@4.0.2":
+    resolution:
+      {
+        integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
       }
 
   "@types/eslint@9.6.1":
@@ -2585,6 +2782,56 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  "@vitest/expect@4.1.5":
+    resolution:
+      {
+        integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==,
+      }
+
+  "@vitest/mocker@4.1.5":
+    resolution:
+      {
+        integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==,
+      }
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  "@vitest/pretty-format@4.1.5":
+    resolution:
+      {
+        integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==,
+      }
+
+  "@vitest/runner@4.1.5":
+    resolution:
+      {
+        integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==,
+      }
+
+  "@vitest/snapshot@4.1.5":
+    resolution:
+      {
+        integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==,
+      }
+
+  "@vitest/spy@4.1.5":
+    resolution:
+      {
+        integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==,
+      }
+
+  "@vitest/utils@4.1.5":
+    resolution:
+      {
+        integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==,
+      }
+
   acorn-jsx@5.3.2:
     resolution:
       {
@@ -2744,6 +2991,13 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  assertion-error@2.0.1:
+    resolution:
+      {
+        integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
+      }
+    engines: { node: ">=12" }
+
   ast-types-flow@0.0.8:
     resolution:
       {
@@ -2892,6 +3146,13 @@ packages:
         integrity: sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==,
       }
 
+  chai@6.2.2:
+    resolution:
+      {
+        integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==,
+      }
+    engines: { node: ">=18" }
+
   chalk@4.1.2:
     resolution:
       {
@@ -3012,6 +3273,12 @@ packages:
     resolution:
       {
         integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
+      }
+
+  convert-source-map@2.0.0:
+    resolution:
+      {
+        integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
       }
 
   cookie@0.7.1:
@@ -3352,6 +3619,12 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  es-module-lexer@2.1.0:
+    resolution:
+      {
+        integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==,
+      }
+
   es-object-atoms@1.1.1:
     resolution:
       {
@@ -3571,6 +3844,12 @@ packages:
       }
     engines: { node: ">=4.0" }
 
+  estree-walker@3.0.3:
+    resolution:
+      {
+        integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
+      }
+
   esutils@2.0.3:
     resolution:
       {
@@ -3583,6 +3862,13 @@ packages:
       {
         integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==,
       }
+
+  expect-type@1.3.0:
+    resolution:
+      {
+        integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==,
+      }
+    engines: { node: ">=12.0.0" }
 
   fast-deep-equal@3.1.3:
     resolution:
@@ -3824,6 +4110,12 @@ packages:
         integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==,
       }
     engines: { node: ">= 0.4" }
+
+  globrex@0.1.2:
+    resolution:
+      {
+        integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==,
+      }
 
   gopd@1.2.0:
     resolution:
@@ -4259,6 +4551,112 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
+  lightningcss-android-arm64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution:
+      {
+        integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution:
+      {
+        integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution:
+      {
+        integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution:
+      {
+        integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution:
+      {
+        integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution:
+      {
+        integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution:
+      {
+        integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution:
+      {
+        integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+
   lilconfig@3.1.3:
     resolution:
       {
@@ -4333,6 +4731,12 @@ packages:
       }
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  magic-string@0.30.21:
+    resolution:
+      {
+        integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
+      }
 
   math-intrinsics@1.1.0:
     resolution:
@@ -4571,6 +4975,12 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  obug@2.1.1:
+    resolution:
+      {
+        integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
+      }
+
   onetime@7.0.0:
     resolution:
       {
@@ -4652,6 +5062,12 @@ packages:
       }
     engines: { node: ">=16 || 14 >=14.18" }
 
+  pathe@2.0.3:
+    resolution:
+      {
+        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+      }
+
   picocolors@1.1.1:
     resolution:
       {
@@ -4669,6 +5085,13 @@ packages:
     resolution:
       {
         integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
+      }
+    engines: { node: ">=12" }
+
+  picomatch@4.0.4:
+    resolution:
+      {
+        integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
       }
     engines: { node: ">=12" }
 
@@ -4760,6 +5183,13 @@ packages:
     resolution:
       {
         integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
+
+  postcss@8.5.12:
+    resolution:
+      {
+        integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==,
       }
     engines: { node: ^10 || ^12 || >=14 }
 
@@ -5084,6 +5514,14 @@ packages:
         integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
       }
 
+  rolldown@1.0.0-rc.17:
+    resolution:
+      {
+        integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution:
       {
@@ -5208,6 +5646,12 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  siginfo@2.0.0:
+    resolution:
+      {
+        integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
+      }
+
   signal-exit@4.1.0:
     resolution:
       {
@@ -5252,6 +5696,18 @@ packages:
     resolution:
       {
         integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==,
+      }
+
+  stackback@0.0.2:
+    resolution:
+      {
+        integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
+      }
+
+  std-env@4.1.0:
+    resolution:
+      {
+        integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==,
       }
 
   stop-iteration-iterator@1.1.0:
@@ -5452,12 +5908,39 @@ packages:
         integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==,
       }
 
+  tinybench@2.9.0:
+    resolution:
+      {
+        integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
+      }
+
+  tinyexec@1.1.1:
+    resolution:
+      {
+        integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==,
+      }
+    engines: { node: ">=18" }
+
   tinyglobby@0.2.15:
     resolution:
       {
         integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
       }
     engines: { node: ">=12.0.0" }
+
+  tinyglobby@0.2.16:
+    resolution:
+      {
+        integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==,
+      }
+    engines: { node: ">=12.0.0" }
+
+  tinyrainbow@3.1.0:
+    resolution:
+      {
+        integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==,
+      }
+    engines: { node: ">=14.0.0" }
 
   to-regex-range@5.0.1:
     resolution:
@@ -5480,6 +5963,19 @@ packages:
       {
         integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==,
       }
+
+  tsconfck@3.1.6:
+    resolution:
+      {
+        integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==,
+      }
+    engines: { node: ^18 || >=20 }
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   tsconfig-paths@3.15.0:
     resolution:
@@ -5610,6 +6106,104 @@ packages:
         integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
       }
 
+  vite-tsconfig-paths@6.1.1:
+    resolution:
+      {
+        integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==,
+      }
+    peerDependencies:
+      vite: "*"
+
+  vite@8.0.10:
+    resolution:
+      {
+        integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+    peerDependencies:
+      "@types/node": ^20.19.0 || >=22.12.0
+      "@vitejs/devtools": ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: ">=1.21.0"
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: ">=0.54.8"
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+      "@vitejs/devtools":
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution:
+      {
+        integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==,
+      }
+    engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
+    hasBin: true
+    peerDependencies:
+      "@edge-runtime/vm": "*"
+      "@opentelemetry/api": ^1.9.0
+      "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+      "@vitest/browser-playwright": 4.1.5
+      "@vitest/browser-preview": 4.1.5
+      "@vitest/browser-webdriverio": 4.1.5
+      "@vitest/coverage-istanbul": 4.1.5
+      "@vitest/coverage-v8": 4.1.5
+      "@vitest/ui": 4.1.5
+      happy-dom: "*"
+      jsdom: "*"
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      "@edge-runtime/vm":
+        optional: true
+      "@opentelemetry/api":
+        optional: true
+      "@types/node":
+        optional: true
+      "@vitest/browser-playwright":
+        optional: true
+      "@vitest/browser-preview":
+        optional: true
+      "@vitest/browser-webdriverio":
+        optional: true
+      "@vitest/coverage-istanbul":
+        optional: true
+      "@vitest/coverage-v8":
+        optional: true
+      "@vitest/ui":
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-vitals@5.1.0:
     resolution:
       {
@@ -5650,6 +6244,14 @@ packages:
         integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
       }
     engines: { node: ">= 8" }
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution:
+      {
+        integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==,
+      }
+    engines: { node: ">=8" }
     hasBin: true
 
   word-wrap@1.2.5:
@@ -5762,9 +6364,20 @@ snapshots:
 
   "@drizzle-team/brocli@0.10.2": {}
 
+  "@emnapi/core@1.10.0":
+    dependencies:
+      "@emnapi/wasi-threads": 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   "@emnapi/core@1.5.0":
     dependencies:
       "@emnapi/wasi-threads": 1.1.0
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/runtime@1.10.0":
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -5774,6 +6387,11 @@ snapshots:
     optional: true
 
   "@emnapi/wasi-threads@1.1.0":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/wasi-threads@1.2.1":
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -6113,6 +6731,13 @@ snapshots:
       "@tybys/wasm-util": 0.10.1
     optional: true
 
+  "@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
+    dependencies:
+      "@emnapi/core": 1.10.0
+      "@emnapi/runtime": 1.10.0
+      "@tybys/wasm-util": 0.10.1
+    optional: true
+
   "@next/env@15.0.7": {}
 
   "@next/eslint-plugin-next@15.5.3":
@@ -6232,6 +6857,8 @@ snapshots:
       "@opentelemetry/semantic-conventions": 1.39.0
 
   "@opentelemetry/semantic-conventions@1.39.0": {}
+
+  "@oxc-project/types@0.127.0": {}
 
   "@panva/hkdf@1.2.1": {}
 
@@ -6861,9 +7488,62 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  "@rolldown/binding-android-arm64@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-darwin-arm64@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-darwin-x64@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-freebsd-x64@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-linux-x64-musl@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-openharmony-arm64@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-wasm32-wasi@1.0.0-rc.17":
+    dependencies:
+      "@emnapi/core": 1.10.0
+      "@emnapi/runtime": 1.10.0
+      "@napi-rs/wasm-runtime": 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.17":
+    optional: true
+
+  "@rolldown/pluginutils@1.0.0-rc.17": {}
+
   "@rtsao/scc@1.1.0": {}
 
   "@rushstack/eslint-patch@1.12.0": {}
+
+  "@standard-schema/spec@1.1.0": {}
 
   "@swc/counter@0.1.3": {}
 
@@ -6913,7 +7593,14 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  "@types/chai@5.2.3":
+    dependencies:
+      "@types/deep-eql": 4.0.2
+      assertion-error: 2.0.1
+
   "@types/cookie@0.6.0": {}
+
+  "@types/deep-eql@4.0.2": {}
 
   "@types/eslint@9.6.1":
     dependencies:
@@ -7096,6 +7783,47 @@ snapshots:
   "@unrs/resolver-binding-win32-x64-msvc@1.11.1":
     optional: true
 
+  "@vitest/expect@4.1.5":
+    dependencies:
+      "@standard-schema/spec": 1.1.0
+      "@types/chai": 5.2.3
+      "@vitest/spy": 4.1.5
+      "@vitest/utils": 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  "@vitest/mocker@4.1.5(vite@8.0.10(@types/node@22.18.6)(esbuild@0.25.10)(jiti@1.21.7)(yaml@2.8.1))":
+    dependencies:
+      "@vitest/spy": 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@22.18.6)(esbuild@0.25.10)(jiti@1.21.7)(yaml@2.8.1)
+
+  "@vitest/pretty-format@4.1.5":
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  "@vitest/runner@4.1.5":
+    dependencies:
+      "@vitest/utils": 4.1.5
+      pathe: 2.0.3
+
+  "@vitest/snapshot@4.1.5":
+    dependencies:
+      "@vitest/pretty-format": 4.1.5
+      "@vitest/utils": 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  "@vitest/spy@4.1.5": {}
+
+  "@vitest/utils@4.1.5":
+    dependencies:
+      "@vitest/pretty-format": 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -7209,6 +7937,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -7282,6 +8012,8 @@ snapshots:
   camelcase-css@2.0.1: {}
 
   caniuse-lite@1.0.30001743: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -7361,6 +8093,8 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie@0.7.1: {}
 
   copy-anything@3.0.5:
@@ -7429,8 +8163,7 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  detect-libc@2.1.0:
-    optional: true
+  detect-libc@2.1.0: {}
 
   detect-node-es@1.1.0: {}
 
@@ -7555,6 +8288,8 @@ snapshots:
       internal-slot: 1.1.0
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -7835,9 +8570,15 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      "@types/estree": 1.0.8
+
   esutils@2.0.3: {}
 
   eventemitter3@5.0.1: {}
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -7868,6 +8609,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   fflate@0.4.8: {}
 
@@ -7989,6 +8734,8 @@ snapshots:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
+
+  globrex@0.1.2: {}
 
   gopd@1.2.0: {}
 
@@ -8224,6 +8971,55 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.0
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
@@ -8277,6 +9073,10 @@ snapshots:
   lucide-react@0.544.0(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  magic-string@0.30.21:
+    dependencies:
+      "@jridgewell/sourcemap-codec": 1.5.5
 
   math-intrinsics@1.1.0: {}
 
@@ -8408,6 +9208,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.1: {}
+
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
@@ -8456,11 +9258,15 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  picomatch@4.0.4: {}
 
   pidtree@0.6.0: {}
 
@@ -8502,6 +9308,12 @@ snapshots:
   postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -8684,6 +9496,27 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      "@oxc-project/types": 0.127.0
+      "@rolldown/pluginutils": 1.0.0-rc.17
+    optionalDependencies:
+      "@rolldown/binding-android-arm64": 1.0.0-rc.17
+      "@rolldown/binding-darwin-arm64": 1.0.0-rc.17
+      "@rolldown/binding-darwin-x64": 1.0.0-rc.17
+      "@rolldown/binding-freebsd-x64": 1.0.0-rc.17
+      "@rolldown/binding-linux-arm-gnueabihf": 1.0.0-rc.17
+      "@rolldown/binding-linux-arm64-gnu": 1.0.0-rc.17
+      "@rolldown/binding-linux-arm64-musl": 1.0.0-rc.17
+      "@rolldown/binding-linux-ppc64-gnu": 1.0.0-rc.17
+      "@rolldown/binding-linux-s390x-gnu": 1.0.0-rc.17
+      "@rolldown/binding-linux-x64-gnu": 1.0.0-rc.17
+      "@rolldown/binding-linux-x64-musl": 1.0.0-rc.17
+      "@rolldown/binding-openharmony-arm64": 1.0.0-rc.17
+      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.17
+      "@rolldown/binding-win32-arm64-msvc": 1.0.0-rc.17
+      "@rolldown/binding-win32-x64-msvc": 1.0.0-rc.17
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -8800,6 +9633,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-swizzle@0.2.4:
@@ -8822,6 +9657,10 @@ snapshots:
   source-map@0.6.1: {}
 
   stable-hash@0.0.5: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -8983,10 +9822,21 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.1: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -8997,6 +9847,10 @@ snapshots:
       typescript: 5.9.2
 
   ts-interface-checker@0.1.13: {}
+
+  tsconfck@3.1.6(typescript@5.9.2):
+    optionalDependencies:
+      typescript: 5.9.2
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -9108,6 +9962,58 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  vite-tsconfig-paths@6.1.1(typescript@5.9.2)(vite@8.0.10(@types/node@22.18.6)(esbuild@0.25.10)(jiti@1.21.7)(yaml@2.8.1)):
+    dependencies:
+      debug: 4.4.3
+      globrex: 0.1.2
+      tsconfck: 3.1.6(typescript@5.9.2)
+      vite: 8.0.10(@types/node@22.18.6)(esbuild@0.25.10)(jiti@1.21.7)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  vite@8.0.10(@types/node@22.18.6)(esbuild@0.25.10)(jiti@1.21.7)(yaml@2.8.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      "@types/node": 22.18.6
+      esbuild: 0.25.10
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      yaml: 2.8.1
+
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@22.18.6)(vite@8.0.10(@types/node@22.18.6)(esbuild@0.25.10)(jiti@1.21.7)(yaml@2.8.1)):
+    dependencies:
+      "@vitest/expect": 4.1.5
+      "@vitest/mocker": 4.1.5(vite@8.0.10(@types/node@22.18.6)(esbuild@0.25.10)(jiti@1.21.7)(yaml@2.8.1))
+      "@vitest/pretty-format": 4.1.5
+      "@vitest/runner": 4.1.5
+      "@vitest/snapshot": 4.1.5
+      "@vitest/spy": 4.1.5
+      "@vitest/utils": 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@22.18.6)(esbuild@0.25.10)(jiti@1.21.7)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      "@opentelemetry/api": 1.9.0
+      "@types/node": 22.18.6
+    transitivePeerDependencies:
+      - msw
+
   web-vitals@5.1.0: {}
 
   which-boxed-primitive@1.1.1:
@@ -9154,6 +10060,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/src/components/raid-planner/character-summary-panel.tsx
+++ b/src/components/raid-planner/character-summary-panel.tsx
@@ -4,32 +4,22 @@ import { useState } from "react";
 import { ChevronDown, ChevronUp, ChevronRight } from "lucide-react";
 import { ClassIcon } from "~/components/ui/class-icon";
 import { AA_CLASS_COLORS } from "~/lib/aa-formatting";
-import { AATemplateRenderer } from "./aa-template-renderer";
-import type { RaidPlanCharacter, AASlotAssignment } from "./types";
 
 export interface CharacterEncounterSummary {
   encounterId: string | "default";
   encounterName: string;
   slotNames: string[];
-  /** extractCharacterLines(fullTemplate, slotNames).join('\n') */
-  template: string;
-  /** Assignments filtered to this encounter context */
-  slotAssignments: AASlotAssignment[];
-  /** planId when encounterId === "default"; encounter UUID otherwise */
-  contextId: string;
 }
 
 interface CharacterSummaryPanelProps {
   viewAsCharacter: { name: string; class: string | null };
   encounterSummaries: CharacterEncounterSummary[];
-  allCharacters: RaidPlanCharacter[];
   onEncounterClick: (encounterId: string) => void;
 }
 
 export function CharacterSummaryPanel({
   viewAsCharacter,
   encounterSummaries,
-  allCharacters,
   onEncounterClick,
 }: CharacterSummaryPanelProps) {
   const [showDetails, setShowDetails] = useState(true);
@@ -71,7 +61,7 @@ export function CharacterSummaryPanel({
             </span>{" "}
             has assignments in{" "}
             {summaryEncounters.map((s, i) => (
-              <span key={s.contextId}>
+              <span key={s.encounterId}>
                 <span className="font-semibold text-foreground">
                   {s.encounterName}
                 </span>{" "}
@@ -107,43 +97,30 @@ export function CharacterSummaryPanel({
         )}
       </div>
 
-      {/* Encounter masonry */}
+      {/* Encounter list — two columns, no cards */}
       {showDetails && encounterSummaries.length > 0 && (
         <div className="border-t border-border px-3 py-2">
-          <div className="columns-2 gap-2 lg:columns-3">
+          <div className="columns-2 gap-x-6">
             {encounterSummaries.map((summary) => (
               <button
-                key={summary.contextId}
+                key={summary.encounterId}
                 type="button"
                 onClick={() => onEncounterClick(summary.encounterId)}
-                className="mb-2 w-full cursor-pointer break-inside-avoid overflow-hidden rounded-md border border-border bg-muted/30 text-left transition-colors hover:border-muted-foreground/50 hover:bg-muted/50"
+                className="flex w-full break-inside-avoid items-center gap-2 py-0.5 text-left text-sm transition-opacity hover:opacity-70"
               >
-                <div className="flex items-center gap-1.5 border-b border-border px-2 py-1">
-                  <div className="h-3 w-0.5 shrink-0 rounded-full bg-purple-400" />
-                  <span className="flex-1 truncate text-sm font-semibold text-foreground">
-                    {summary.encounterName}
-                  </span>
-                  <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
-                </div>
-                <div className="p-1.5">
-                  <AATemplateRenderer
-                    template={summary.template}
-                    encounterId={
-                      summary.encounterId !== "default"
-                        ? summary.contextId
-                        : undefined
-                    }
-                    raidPlanId={
-                      summary.encounterId === "default"
-                        ? summary.contextId
-                        : undefined
-                    }
-                    characters={allCharacters}
-                    slotAssignments={summary.slotAssignments}
-                    disabled
-                    hideUnassigned
-                    skipDndContext
-                  />
+                <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground/50" />
+                <span className="shrink-0 font-semibold text-foreground">
+                  {summary.encounterName}
+                </span>
+                <div className="flex flex-wrap gap-1">
+                  {summary.slotNames.map((name) => (
+                    <span
+                      key={name}
+                      className="inline-block rounded border border-purple-500/25 bg-purple-500/10 px-1 text-xs font-medium text-purple-300"
+                    >
+                      {name}
+                    </span>
+                  ))}
                 </div>
               </button>
             ))}

--- a/src/components/raid-planner/character-summary-panel.tsx
+++ b/src/components/raid-planner/character-summary-panel.tsx
@@ -42,8 +42,9 @@ export function CharacterSummaryPanel({
       ] ?? undefined)
     : undefined;
 
-  const summaryEncounters = encounterSummaries.slice(0, 3);
-  const remainingCount = encounterSummaries.length - 3;
+  const MAX_SUMMARY = 3;
+  const summaryEncounters = encounterSummaries.slice(0, MAX_SUMMARY);
+  const remainingCount = Math.max(0, encounterSummaries.length - MAX_SUMMARY);
 
   return (
     <div className="mb-4 overflow-hidden rounded-lg border border-border bg-card">
@@ -114,7 +115,7 @@ export function CharacterSummaryPanel({
           <div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
             {encounterSummaries.map((summary) => (
               <button
-                key={summary.encounterId}
+                key={summary.contextId}
                 type="button"
                 onClick={() => onEncounterClick(summary.encounterId)}
                 className="w-full cursor-pointer overflow-hidden rounded-md border border-border bg-muted/30 text-left transition-colors hover:border-muted-foreground/50 hover:bg-muted/50"

--- a/src/components/raid-planner/character-summary-panel.tsx
+++ b/src/components/raid-planner/character-summary-panel.tsx
@@ -23,7 +23,6 @@ interface CharacterSummaryPanelProps {
   viewAsCharacter: { name: string; class: string | null };
   encounterSummaries: CharacterEncounterSummary[];
   allCharacters: RaidPlanCharacter[];
-  userCharacterIds: number[];
   onEncounterClick: (encounterId: string) => void;
 }
 
@@ -31,7 +30,6 @@ export function CharacterSummaryPanel({
   viewAsCharacter,
   encounterSummaries,
   allCharacters,
-  userCharacterIds,
   onEncounterClick,
 }: CharacterSummaryPanelProps) {
   const [showDetails, setShowDetails] = useState(true);
@@ -145,7 +143,6 @@ export function CharacterSummaryPanel({
                     disabled
                     hideUnassigned
                     skipDndContext
-                    userCharacterIds={userCharacterIds}
                   />
                 </div>
               </button>

--- a/src/components/raid-planner/character-summary-panel.tsx
+++ b/src/components/raid-planner/character-summary-panel.tsx
@@ -73,7 +73,7 @@ export function CharacterSummaryPanel({
             </span>{" "}
             has assignments in{" "}
             {summaryEncounters.map((s, i) => (
-              <span key={s.encounterId}>
+              <span key={s.contextId}>
                 <span className="font-semibold text-foreground">
                   {s.encounterName}
                 </span>{" "}

--- a/src/components/raid-planner/character-summary-panel.tsx
+++ b/src/components/raid-planner/character-summary-panel.tsx
@@ -94,6 +94,7 @@ export function CharacterSummaryPanel({
         )}
         {encounterSummaries.length > 0 && (
           <button
+            type="button"
             onClick={() => setShowDetails((v) => !v)}
             className="flex shrink-0 items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:border-muted-foreground hover:text-foreground"
           >
@@ -112,10 +113,11 @@ export function CharacterSummaryPanel({
         <div className="border-t border-border p-3">
           <div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
             {encounterSummaries.map((summary) => (
-              <div
+              <button
                 key={summary.encounterId}
+                type="button"
                 onClick={() => onEncounterClick(summary.encounterId)}
-                className="cursor-pointer overflow-hidden rounded-md border border-border bg-muted/30 transition-colors hover:border-muted-foreground/50 hover:bg-muted/50"
+                className="w-full cursor-pointer overflow-hidden rounded-md border border-border bg-muted/30 text-left transition-colors hover:border-muted-foreground/50 hover:bg-muted/50"
               >
                 <div className="flex items-center gap-2 border-b border-border px-3 py-1.5">
                   <div className="h-3 w-0.5 shrink-0 rounded-full bg-purple-400" />
@@ -145,7 +147,7 @@ export function CharacterSummaryPanel({
                     userCharacterIds={userCharacterIds}
                   />
                 </div>
-              </div>
+              </button>
             ))}
           </div>
         </div>

--- a/src/components/raid-planner/character-summary-panel.tsx
+++ b/src/components/raid-planner/character-summary-panel.tsx
@@ -151,7 +151,7 @@ export function CharacterSummaryPanel({
                       </TooltipTrigger>
                       <TooltipContent
                         side="right"
-                        className="w-auto max-w-sm border border-border bg-card p-2 text-foreground shadow-xl"
+                        className="w-auto max-w-sm bg-card p-0 text-foreground shadow-xl"
                       >
                         <AATemplateRenderer
                           template={summary.template}

--- a/src/components/raid-planner/character-summary-panel.tsx
+++ b/src/components/raid-planner/character-summary-panel.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronUp, ChevronRight } from "lucide-react";
+import { ClassIcon } from "~/components/ui/class-icon";
+import { AA_CLASS_COLORS } from "~/lib/aa-formatting";
+import { AATemplateRenderer } from "./aa-template-renderer";
+import type { RaidPlanCharacter, AASlotAssignment } from "./types";
+
+export interface CharacterEncounterSummary {
+  encounterId: string | "default";
+  encounterName: string;
+  slotNames: string[];
+  /** extractCharacterLines(fullTemplate, slotNames).join('\n') */
+  template: string;
+  /** Assignments filtered to this encounter context */
+  slotAssignments: AASlotAssignment[];
+  /** planId when encounterId === "default"; encounter UUID otherwise */
+  contextId: string;
+}
+
+interface CharacterSummaryPanelProps {
+  viewAsCharacter: { name: string; class: string | null };
+  encounterSummaries: CharacterEncounterSummary[];
+  allCharacters: RaidPlanCharacter[];
+  userCharacterIds: number[];
+  onEncounterClick: (encounterId: string) => void;
+}
+
+export function CharacterSummaryPanel({
+  viewAsCharacter,
+  encounterSummaries,
+  allCharacters,
+  userCharacterIds,
+  onEncounterClick,
+}: CharacterSummaryPanelProps) {
+  const [showDetails, setShowDetails] = useState(true);
+
+  const classColor = viewAsCharacter.class
+    ? (AA_CLASS_COLORS[
+        viewAsCharacter.class.toLowerCase().replace(/\s+/g, "")
+      ] ?? undefined)
+    : undefined;
+
+  const summaryEncounters = encounterSummaries.slice(0, 3);
+  const remainingCount = encounterSummaries.length - 3;
+
+  return (
+    <div className="mb-4 overflow-hidden rounded-lg border border-border bg-card">
+      {/* Summary line */}
+      <div className="flex items-start justify-between gap-3 p-3">
+        {encounterSummaries.length === 0 ? (
+          <p className="text-sm italic text-muted-foreground">
+            No assignments found for{" "}
+            <span className="font-semibold">{viewAsCharacter.name}</span> — show
+            up, stay alive, and try not to stand in the bad. GLHF.
+          </p>
+        ) : (
+          <p className="flex-1 text-sm leading-relaxed">
+            {viewAsCharacter.class && (
+              <ClassIcon
+                characterClass={viewAsCharacter.class}
+                px={16}
+                className="mr-1 inline-block align-middle"
+              />
+            )}
+            <span
+              className="font-bold"
+              style={classColor ? { color: classColor } : undefined}
+            >
+              {viewAsCharacter.name}
+            </span>{" "}
+            has assignments in{" "}
+            {summaryEncounters.map((s, i) => (
+              <span key={s.encounterId}>
+                <span className="font-semibold text-foreground">
+                  {s.encounterName}
+                </span>{" "}
+                (
+                {s.slotNames.map((name, j) => (
+                  <span key={name}>
+                    <span className="inline-block rounded border border-purple-500/25 bg-purple-500/10 px-1 text-xs font-medium text-purple-300">
+                      {name}
+                    </span>
+                    {j < s.slotNames.length - 1 ? " " : ""}
+                  </span>
+                ))}
+                ){i < summaryEncounters.length - 1 ? ", " : ""}
+              </span>
+            ))}
+            {remainingCount > 0 &&
+              `, and ${remainingCount} more encounter${remainingCount !== 1 ? "s" : ""}.`}
+          </p>
+        )}
+        {encounterSummaries.length > 0 && (
+          <button
+            onClick={() => setShowDetails((v) => !v)}
+            className="flex shrink-0 items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:border-muted-foreground hover:text-foreground"
+          >
+            {showDetails ? (
+              <ChevronUp className="h-3 w-3" />
+            ) : (
+              <ChevronDown className="h-3 w-3" />
+            )}
+            {showDetails ? "Hide details" : "Show details"}
+          </button>
+        )}
+      </div>
+
+      {/* Encounter grid */}
+      {showDetails && encounterSummaries.length > 0 && (
+        <div className="border-t border-border p-3">
+          <div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
+            {encounterSummaries.map((summary) => (
+              <div
+                key={summary.encounterId}
+                onClick={() => onEncounterClick(summary.encounterId)}
+                className="cursor-pointer overflow-hidden rounded-md border border-border bg-muted/30 transition-colors hover:border-muted-foreground/50 hover:bg-muted/50"
+              >
+                <div className="flex items-center gap-2 border-b border-border px-3 py-1.5">
+                  <div className="h-3 w-0.5 shrink-0 rounded-full bg-purple-400" />
+                  <span className="flex-1 truncate text-xs font-semibold text-foreground">
+                    {summary.encounterName}
+                  </span>
+                  <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+                </div>
+                <div className="p-2">
+                  <AATemplateRenderer
+                    template={summary.template}
+                    encounterId={
+                      summary.encounterId !== "default"
+                        ? summary.contextId
+                        : undefined
+                    }
+                    raidPlanId={
+                      summary.encounterId === "default"
+                        ? summary.contextId
+                        : undefined
+                    }
+                    characters={allCharacters}
+                    slotAssignments={summary.slotAssignments}
+                    disabled
+                    hideUnassigned
+                    skipDndContext
+                    userCharacterIds={userCharacterIds}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/raid-planner/character-summary-panel.tsx
+++ b/src/components/raid-planner/character-summary-panel.tsx
@@ -77,17 +77,8 @@ export function CharacterSummaryPanel({
               <span key={s.encounterId}>
                 <span className="font-semibold text-foreground">
                   {s.encounterName}
-                </span>{" "}
-                (
-                {s.slotNames.map((name, j) => (
-                  <span key={name}>
-                    <span className="inline-block rounded border border-purple-500/25 bg-purple-500/10 px-1 text-xs font-medium text-purple-300">
-                      {name}
-                    </span>
-                    {j < s.slotNames.length - 1 ? " " : ""}
-                  </span>
-                ))}
-                ){i < summaryEncounters.length - 1 ? ", " : ""}
+                </span>
+                {i < summaryEncounters.length - 1 ? ", " : ""}
               </span>
             ))}
             {remainingCount > 0 &&

--- a/src/components/raid-planner/character-summary-panel.tsx
+++ b/src/components/raid-planner/character-summary-panel.tsx
@@ -4,22 +4,35 @@ import { useState } from "react";
 import { ChevronDown, ChevronUp, ChevronRight } from "lucide-react";
 import { ClassIcon } from "~/components/ui/class-icon";
 import { AA_CLASS_COLORS } from "~/lib/aa-formatting";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "~/components/ui/tooltip";
+import { AATemplateRenderer } from "./aa-template-renderer";
+import type { RaidPlanCharacter, AASlotAssignment } from "./types";
 
 export interface CharacterEncounterSummary {
   encounterId: string | "default";
   encounterName: string;
   slotNames: string[];
+  template: string;
+  slotAssignments: AASlotAssignment[];
+  contextId: string;
 }
 
 interface CharacterSummaryPanelProps {
   viewAsCharacter: { name: string; class: string | null };
   encounterSummaries: CharacterEncounterSummary[];
+  allCharacters: RaidPlanCharacter[];
   onEncounterClick: (encounterId: string) => void;
 }
 
 export function CharacterSummaryPanel({
   viewAsCharacter,
   encounterSummaries,
+  allCharacters,
   onEncounterClick,
 }: CharacterSummaryPanelProps) {
   const [showDetails, setShowDetails] = useState(true);
@@ -100,43 +113,71 @@ export function CharacterSummaryPanel({
       {/* Encounter list — two compact columns, left-aligned */}
       {showDetails && encounterSummaries.length > 0 && (
         <div className="border-t border-border px-3 py-2">
-          <div className="flex items-start gap-x-8">
-            {[
-              encounterSummaries.slice(
-                0,
-                Math.ceil(encounterSummaries.length / 2),
-              ),
-              encounterSummaries.slice(
-                Math.ceil(encounterSummaries.length / 2),
-              ),
-            ].map((col, ci) => (
-              <div key={ci} className="flex flex-col">
-                {col.map((summary) => (
-                  <button
-                    key={summary.encounterId}
-                    type="button"
-                    onClick={() => onEncounterClick(summary.encounterId)}
-                    className="flex items-center gap-2 py-0.5 text-left text-sm transition-opacity hover:opacity-70"
-                  >
-                    <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground/50" />
-                    <span className="shrink-0 font-semibold text-foreground">
-                      {summary.encounterName}
-                    </span>
-                    <div className="flex flex-wrap gap-1">
-                      {summary.slotNames.map((name) => (
-                        <span
-                          key={name}
-                          className="inline-block rounded border border-purple-500/25 bg-purple-500/10 px-1 text-xs font-medium text-purple-300"
+          <TooltipProvider delayDuration={300}>
+            <div className="flex items-start gap-x-8">
+              {[
+                encounterSummaries.slice(
+                  0,
+                  Math.ceil(encounterSummaries.length / 2),
+                ),
+                encounterSummaries.slice(
+                  Math.ceil(encounterSummaries.length / 2),
+                ),
+              ].map((col, ci) => (
+                <div key={ci} className="flex flex-col">
+                  {col.map((summary) => (
+                    <Tooltip key={summary.encounterId}>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={() => onEncounterClick(summary.encounterId)}
+                          className="flex items-center gap-2 py-0.5 text-left text-sm transition-opacity hover:opacity-70"
                         >
-                          {name}
-                        </span>
-                      ))}
-                    </div>
-                  </button>
-                ))}
-              </div>
-            ))}
-          </div>
+                          <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground/50" />
+                          <span className="shrink-0 font-semibold text-foreground">
+                            {summary.encounterName}
+                          </span>
+                          <div className="flex flex-wrap gap-1">
+                            {summary.slotNames.map((name) => (
+                              <span
+                                key={name}
+                                className="inline-block rounded border border-purple-500/25 bg-purple-500/10 px-1 text-xs font-medium text-purple-300"
+                              >
+                                {name}
+                              </span>
+                            ))}
+                          </div>
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent
+                        side="right"
+                        className="w-auto max-w-sm border border-border bg-card p-2 text-foreground shadow-xl"
+                      >
+                        <AATemplateRenderer
+                          template={summary.template}
+                          encounterId={
+                            summary.encounterId !== "default"
+                              ? summary.contextId
+                              : undefined
+                          }
+                          raidPlanId={
+                            summary.encounterId === "default"
+                              ? summary.contextId
+                              : undefined
+                          }
+                          characters={allCharacters}
+                          slotAssignments={summary.slotAssignments}
+                          disabled
+                          hideUnassigned
+                          skipDndContext
+                        />
+                      </TooltipContent>
+                    </Tooltip>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </TooltipProvider>
         </div>
       )}
     </div>

--- a/src/components/raid-planner/character-summary-panel.tsx
+++ b/src/components/raid-planner/character-summary-panel.tsx
@@ -97,32 +97,44 @@ export function CharacterSummaryPanel({
         )}
       </div>
 
-      {/* Encounter list — two columns, no cards */}
+      {/* Encounter list — two compact columns, left-aligned */}
       {showDetails && encounterSummaries.length > 0 && (
         <div className="border-t border-border px-3 py-2">
-          <div className="columns-2 gap-x-6">
-            {encounterSummaries.map((summary) => (
-              <button
-                key={summary.encounterId}
-                type="button"
-                onClick={() => onEncounterClick(summary.encounterId)}
-                className="flex w-full break-inside-avoid items-center gap-2 py-0.5 text-left text-sm transition-opacity hover:opacity-70"
-              >
-                <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground/50" />
-                <span className="shrink-0 font-semibold text-foreground">
-                  {summary.encounterName}
-                </span>
-                <div className="flex flex-wrap gap-1">
-                  {summary.slotNames.map((name) => (
-                    <span
-                      key={name}
-                      className="inline-block rounded border border-purple-500/25 bg-purple-500/10 px-1 text-xs font-medium text-purple-300"
-                    >
-                      {name}
+          <div className="flex items-start gap-x-8">
+            {[
+              encounterSummaries.slice(
+                0,
+                Math.ceil(encounterSummaries.length / 2),
+              ),
+              encounterSummaries.slice(
+                Math.ceil(encounterSummaries.length / 2),
+              ),
+            ].map((col, ci) => (
+              <div key={ci} className="flex flex-col">
+                {col.map((summary) => (
+                  <button
+                    key={summary.encounterId}
+                    type="button"
+                    onClick={() => onEncounterClick(summary.encounterId)}
+                    className="flex items-center gap-2 py-0.5 text-left text-sm transition-opacity hover:opacity-70"
+                  >
+                    <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground/50" />
+                    <span className="shrink-0 font-semibold text-foreground">
+                      {summary.encounterName}
                     </span>
-                  ))}
-                </div>
-              </button>
+                    <div className="flex flex-wrap gap-1">
+                      {summary.slotNames.map((name) => (
+                        <span
+                          key={name}
+                          className="inline-block rounded border border-purple-500/25 bg-purple-500/10 px-1 text-xs font-medium text-purple-300"
+                        >
+                          {name}
+                        </span>
+                      ))}
+                    </div>
+                  </button>
+                ))}
+              </div>
             ))}
           </div>
         </div>

--- a/src/components/raid-planner/character-summary-panel.tsx
+++ b/src/components/raid-planner/character-summary-panel.tsx
@@ -47,7 +47,7 @@ export function CharacterSummaryPanel({
   return (
     <div className="mb-4 overflow-hidden rounded-lg border border-border bg-card">
       {/* Summary line */}
-      <div className="flex items-start justify-between gap-3 p-3">
+      <div className="flex items-start justify-between gap-3 px-3 py-2">
         {encounterSummaries.length === 0 ? (
           <p className="text-sm italic text-muted-foreground">
             No assignments found for{" "}
@@ -107,25 +107,25 @@ export function CharacterSummaryPanel({
         )}
       </div>
 
-      {/* Encounter grid */}
+      {/* Encounter masonry */}
       {showDetails && encounterSummaries.length > 0 && (
-        <div className="border-t border-border p-3">
-          <div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
+        <div className="border-t border-border px-3 py-2">
+          <div className="columns-2 gap-2 lg:columns-3">
             {encounterSummaries.map((summary) => (
               <button
                 key={summary.contextId}
                 type="button"
                 onClick={() => onEncounterClick(summary.encounterId)}
-                className="w-full cursor-pointer overflow-hidden rounded-md border border-border bg-muted/30 text-left transition-colors hover:border-muted-foreground/50 hover:bg-muted/50"
+                className="mb-2 w-full cursor-pointer break-inside-avoid overflow-hidden rounded-md border border-border bg-muted/30 text-left transition-colors hover:border-muted-foreground/50 hover:bg-muted/50"
               >
-                <div className="flex items-center gap-2 border-b border-border px-3 py-1.5">
+                <div className="flex items-center gap-1.5 border-b border-border px-2 py-1">
                   <div className="h-3 w-0.5 shrink-0 rounded-full bg-purple-400" />
-                  <span className="flex-1 truncate text-xs font-semibold text-foreground">
+                  <span className="flex-1 truncate text-sm font-semibold text-foreground">
                     {summary.encounterName}
                   </span>
                   <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
                 </div>
-                <div className="p-2">
+                <div className="p-1.5">
                   <AATemplateRenderer
                     template={summary.template}
                     encounterId={

--- a/src/components/raid-planner/character-summary-panel.tsx
+++ b/src/components/raid-planner/character-summary-panel.tsx
@@ -51,54 +51,44 @@ export function CharacterSummaryPanel({
     <div className="mb-4 overflow-hidden rounded-lg border border-border bg-card">
       {/* Summary line */}
       <div className="flex items-start justify-between gap-3 px-3 py-2">
-        {encounterSummaries.length === 0 ? (
-          <p className="text-sm italic text-muted-foreground">
-            No assignments found for{" "}
-            <span className="font-semibold">{viewAsCharacter.name}</span> — show
-            up, stay alive, and try not to stand in the bad. GLHF.
-          </p>
-        ) : (
-          <p className="flex-1 text-sm leading-relaxed">
-            {viewAsCharacter.class && (
-              <ClassIcon
-                characterClass={viewAsCharacter.class}
-                px={16}
-                className="mr-1 inline-block align-middle"
-              />
-            )}
-            <span
-              className="font-bold"
-              style={classColor ? { color: classColor } : undefined}
-            >
-              {viewAsCharacter.name}
-            </span>{" "}
-            has assignments in{" "}
-            {summaryEncounters.map((s, i) => (
-              <span key={s.encounterId}>
-                <span className="font-semibold text-foreground">
-                  {s.encounterName}
-                </span>
-                {i < summaryEncounters.length - 1 ? ", " : ""}
-              </span>
-            ))}
-            {remainingCount > 0 &&
-              `, and ${remainingCount} more encounter${remainingCount !== 1 ? "s" : ""}.`}
-          </p>
-        )}
-        {encounterSummaries.length > 0 && (
-          <button
-            type="button"
-            onClick={() => setShowDetails((v) => !v)}
-            className="flex shrink-0 items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:border-muted-foreground hover:text-foreground"
+        <p className="flex-1 text-sm leading-relaxed">
+          {viewAsCharacter.class && (
+            <ClassIcon
+              characterClass={viewAsCharacter.class}
+              px={16}
+              className="mr-1 inline-block align-middle"
+            />
+          )}
+          <span
+            className="font-bold"
+            style={classColor ? { color: classColor } : undefined}
           >
-            {showDetails ? (
-              <ChevronUp className="h-3 w-3" />
-            ) : (
-              <ChevronDown className="h-3 w-3" />
-            )}
-            {showDetails ? "Hide details" : "Show details"}
-          </button>
-        )}
+            {viewAsCharacter.name}
+          </span>{" "}
+          has assignments in{" "}
+          {summaryEncounters.map((s, i) => (
+            <span key={s.encounterId}>
+              <span className="font-semibold text-foreground">
+                {s.encounterName}
+              </span>
+              {i < summaryEncounters.length - 1 ? ", " : ""}
+            </span>
+          ))}
+          {remainingCount > 0 &&
+            `, and ${remainingCount} more encounter${remainingCount !== 1 ? "s" : ""}.`}
+        </p>
+        <button
+          type="button"
+          onClick={() => setShowDetails((v) => !v)}
+          className="flex shrink-0 items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:border-muted-foreground hover:text-foreground"
+        >
+          {showDetails ? (
+            <ChevronUp className="h-3 w-3" />
+          ) : (
+            <ChevronDown className="h-3 w-3" />
+          )}
+          {showDetails ? "Hide details" : "Show details"}
+        </button>
       </div>
 
       {/* Encounter list — two compact columns, left-aligned */}

--- a/src/components/raid-planner/raid-plan-public-view.tsx
+++ b/src/components/raid-planner/raid-plan-public-view.tsx
@@ -21,6 +21,11 @@ import { EncounterSidebar } from "./encounter-sidebar";
 import { useBreadcrumb } from "~/components/nav/breadcrumb-context";
 import { buildEncounterCharacters, type RaidPlanCharacter } from "./types";
 import { getGroupCount } from "./constants";
+import { extractCharacterLines } from "~/lib/aa-template";
+import {
+  CharacterSummaryPanel,
+  type CharacterEncounterSummary,
+} from "./character-summary-panel";
 
 import { signIn } from "next-auth/react";
 import { Badge } from "~/components/ui/badge";
@@ -143,6 +148,63 @@ export function RaidPlanPublicView({
 
     return labelsMap;
   }, [userCharacterIds, plan?.characters, plan?.aaSlotAssignments]);
+
+  const encounterSummaries = useMemo((): CharacterEncounterSummary[] => {
+    if (!plan || assignmentLabelsMap.size === 0) return [];
+
+    const summaries: CharacterEncounterSummary[] = [];
+
+    // Default/Trash
+    const defaultSlotNames = assignmentLabelsMap.get("default");
+    if (
+      defaultSlotNames?.length &&
+      plan.useDefaultAA &&
+      plan.defaultAATemplate
+    ) {
+      const lines = extractCharacterLines(
+        plan.defaultAATemplate,
+        defaultSlotNames,
+      );
+      if (lines.length > 0) {
+        summaries.push({
+          encounterId: "default",
+          encounterName: "Default/Trash",
+          slotNames: defaultSlotNames,
+          template: lines.join("\n"),
+          slotAssignments: plan.aaSlotAssignments.filter(
+            (a) => a.raidPlanId === planId && a.encounterId === null,
+          ),
+          contextId: planId,
+        });
+      }
+    }
+
+    // Encounter-specific (sorted by sortOrder)
+    const sortedEncounters = [...plan.encounters].sort(
+      (a, b) => a.sortOrder - b.sortOrder,
+    );
+    for (const encounter of sortedEncounters) {
+      const slotNames = assignmentLabelsMap.get(encounter.id);
+      if (!slotNames?.length || !encounter.useCustomAA || !encounter.aaTemplate)
+        continue;
+
+      const lines = extractCharacterLines(encounter.aaTemplate, slotNames);
+      if (lines.length === 0) continue;
+
+      summaries.push({
+        encounterId: encounter.id,
+        encounterName: encounter.encounterName,
+        slotNames,
+        template: lines.join("\n"),
+        slotAssignments: plan.aaSlotAssignments.filter(
+          (a) => a.encounterId === encounter.id,
+        ),
+        contextId: encounter.id,
+      });
+    }
+
+    return summaries;
+  }, [plan, planId, assignmentLabelsMap]);
 
   // Update breadcrumb to show plan name instead of UUID
   useEffect(() => {
@@ -286,6 +348,16 @@ export function RaidPlanPublicView({
         </div>
 
         <Separator className="my-2" />
+
+        {viewAsCharacterId !== null && viewAsCharacter && (
+          <CharacterSummaryPanel
+            viewAsCharacter={viewAsCharacter}
+            encounterSummaries={encounterSummaries}
+            allCharacters={plan.characters as RaidPlanCharacter[]}
+            userCharacterIds={userCharacterIds}
+            onEncounterClick={setActiveTab}
+          />
+        )}
 
         <Tabs value={activeTab} onValueChange={setActiveTab}>
           <div className="mt-2 grid gap-6 lg:grid-cols-[165px_minmax(0,_1fr)]">

--- a/src/components/raid-planner/raid-plan-public-view.tsx
+++ b/src/components/raid-planner/raid-plan-public-view.tsx
@@ -21,6 +21,7 @@ import { EncounterSidebar } from "./encounter-sidebar";
 import { useBreadcrumb } from "~/components/nav/breadcrumb-context";
 import { buildEncounterCharacters, type RaidPlanCharacter } from "./types";
 import { getGroupCount } from "./constants";
+import { extractCharacterLines } from "~/lib/aa-template";
 import {
   CharacterSummaryPanel,
   type CharacterEncounterSummary,
@@ -160,11 +161,22 @@ export function RaidPlanPublicView({
       plan.useDefaultAA &&
       plan.defaultAATemplate
     ) {
-      summaries.push({
-        encounterId: "default",
-        encounterName: "Default/Trash",
-        slotNames: defaultSlotNames,
-      });
+      const lines = extractCharacterLines(
+        plan.defaultAATemplate,
+        defaultSlotNames,
+      );
+      if (lines.length > 0) {
+        summaries.push({
+          encounterId: "default",
+          encounterName: "Default/Trash",
+          slotNames: defaultSlotNames,
+          template: lines.join("\n"),
+          slotAssignments: plan.aaSlotAssignments.filter(
+            (a) => a.encounterId === null,
+          ),
+          contextId: planId,
+        });
+      }
     }
 
     // Encounters sorted by sortOrder
@@ -176,15 +188,23 @@ export function RaidPlanPublicView({
       if (!slotNames?.length || !encounter.useCustomAA || !encounter.aaTemplate)
         continue;
 
+      const lines = extractCharacterLines(encounter.aaTemplate, slotNames);
+      if (lines.length === 0) continue;
+
       summaries.push({
         encounterId: encounter.id,
         encounterName: encounter.encounterName,
         slotNames,
+        template: lines.join("\n"),
+        slotAssignments: plan.aaSlotAssignments.filter(
+          (a) => a.encounterId === encounter.id,
+        ),
+        contextId: encounter.id,
       });
     }
 
     return summaries;
-  }, [plan, assignmentLabelsMap]);
+  }, [plan, planId, assignmentLabelsMap]);
 
   // Update breadcrumb to show plan name instead of UUID
   useEffect(() => {
@@ -333,6 +353,7 @@ export function RaidPlanPublicView({
           <CharacterSummaryPanel
             viewAsCharacter={viewAsCharacter}
             encounterSummaries={encounterSummaries}
+            allCharacters={plan.characters as RaidPlanCharacter[]}
             onEncounterClick={setActiveTab}
           />
         )}

--- a/src/components/raid-planner/raid-plan-public-view.tsx
+++ b/src/components/raid-planner/raid-plan-public-view.tsx
@@ -21,7 +21,6 @@ import { EncounterSidebar } from "./encounter-sidebar";
 import { useBreadcrumb } from "~/components/nav/breadcrumb-context";
 import { buildEncounterCharacters, type RaidPlanCharacter } from "./types";
 import { getGroupCount } from "./constants";
-import { extractCharacterLines } from "~/lib/aa-template";
 import {
   CharacterSummaryPanel,
   type CharacterEncounterSummary,
@@ -161,25 +160,14 @@ export function RaidPlanPublicView({
       plan.useDefaultAA &&
       plan.defaultAATemplate
     ) {
-      const lines = extractCharacterLines(
-        plan.defaultAATemplate,
-        defaultSlotNames,
-      );
-      if (lines.length > 0) {
-        summaries.push({
-          encounterId: "default",
-          encounterName: "Default/Trash",
-          slotNames: defaultSlotNames,
-          template: lines.join("\n"),
-          slotAssignments: plan.aaSlotAssignments.filter(
-            (a) => a.encounterId === null,
-          ),
-          contextId: planId,
-        });
-      }
+      summaries.push({
+        encounterId: "default",
+        encounterName: "Default/Trash",
+        slotNames: defaultSlotNames,
+      });
     }
 
-    // Encounter-specific (sorted by sortOrder)
+    // Encounters sorted by sortOrder
     const sortedEncounters = [...plan.encounters].sort(
       (a, b) => a.sortOrder - b.sortOrder,
     );
@@ -188,23 +176,15 @@ export function RaidPlanPublicView({
       if (!slotNames?.length || !encounter.useCustomAA || !encounter.aaTemplate)
         continue;
 
-      const lines = extractCharacterLines(encounter.aaTemplate, slotNames);
-      if (lines.length === 0) continue;
-
       summaries.push({
         encounterId: encounter.id,
         encounterName: encounter.encounterName,
         slotNames,
-        template: lines.join("\n"),
-        slotAssignments: plan.aaSlotAssignments.filter(
-          (a) => a.encounterId === encounter.id,
-        ),
-        contextId: encounter.id,
       });
     }
 
     return summaries;
-  }, [plan, planId, assignmentLabelsMap]);
+  }, [plan, assignmentLabelsMap]);
 
   // Update breadcrumb to show plan name instead of UUID
   useEffect(() => {
@@ -353,7 +333,6 @@ export function RaidPlanPublicView({
           <CharacterSummaryPanel
             viewAsCharacter={viewAsCharacter}
             encounterSummaries={encounterSummaries}
-            allCharacters={plan.characters as RaidPlanCharacter[]}
             onEncounterClick={setActiveTab}
           />
         )}

--- a/src/components/raid-planner/raid-plan-public-view.tsx
+++ b/src/components/raid-planner/raid-plan-public-view.tsx
@@ -172,7 +172,7 @@ export function RaidPlanPublicView({
           slotNames: defaultSlotNames,
           template: lines.join("\n"),
           slotAssignments: plan.aaSlotAssignments.filter(
-            (a) => a.raidPlanId === planId && a.encounterId === null,
+            (a) => a.encounterId === null,
           ),
           contextId: planId,
         });

--- a/src/components/raid-planner/raid-plan-public-view.tsx
+++ b/src/components/raid-planner/raid-plan-public-view.tsx
@@ -349,14 +349,16 @@ export function RaidPlanPublicView({
 
         <Separator className="my-2" />
 
-        {viewAsCharacterId !== null && viewAsCharacter && (
-          <CharacterSummaryPanel
-            viewAsCharacter={viewAsCharacter}
-            encounterSummaries={encounterSummaries}
-            allCharacters={plan.characters as RaidPlanCharacter[]}
-            onEncounterClick={setActiveTab}
-          />
-        )}
+        {viewAsCharacterId !== null &&
+          viewAsCharacter &&
+          encounterSummaries.length > 0 && (
+            <CharacterSummaryPanel
+              viewAsCharacter={viewAsCharacter}
+              encounterSummaries={encounterSummaries}
+              allCharacters={plan.characters as RaidPlanCharacter[]}
+              onEncounterClick={setActiveTab}
+            />
+          )}
 
         <Tabs value={activeTab} onValueChange={setActiveTab}>
           <div className="mt-2 grid gap-6 lg:grid-cols-[165px_minmax(0,_1fr)]">

--- a/src/components/raid-planner/raid-plan-public-view.tsx
+++ b/src/components/raid-planner/raid-plan-public-view.tsx
@@ -354,7 +354,6 @@ export function RaidPlanPublicView({
             viewAsCharacter={viewAsCharacter}
             encounterSummaries={encounterSummaries}
             allCharacters={plan.characters as RaidPlanCharacter[]}
-            userCharacterIds={userCharacterIds}
             onEncounterClick={setActiveTab}
           />
         )}

--- a/src/lib/__tests__/aa-template.test.ts
+++ b/src/lib/__tests__/aa-template.test.ts
@@ -68,4 +68,14 @@ describe("extractCharacterLines", () => {
       "OT: {assign:MainTank}",
     ]);
   });
+
+  it("includes {assign:} definition lines for slots referenced via {ref:} in matched lines", () => {
+    // Healer line references the tank slot — renderer needs the tank definition line too
+    const template =
+      "{skull} Tank: {assign:HatefulTank1}\n{cross} {ref:HatefulTank1}: {assign:HatefulTank1Heals}\nUnrelated line";
+    expect(extractCharacterLines(template, ["HatefulTank1Heals"])).toEqual([
+      "{skull} Tank: {assign:HatefulTank1}",
+      "{cross} {ref:HatefulTank1}: {assign:HatefulTank1Heals}",
+    ]);
+  });
 });

--- a/src/lib/__tests__/aa-template.test.ts
+++ b/src/lib/__tests__/aa-template.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { extractCharacterLines } from "../aa-template";
+
+describe("extractCharacterLines", () => {
+  it("returns lines containing {assign:SlotName}", () => {
+    const template = "Line 1\n{skull} Tank: {assign:MainTank}\nLine 3";
+    expect(extractCharacterLines(template, ["MainTank"])).toEqual([
+      "{skull} Tank: {assign:MainTank}",
+    ]);
+  });
+
+  it("returns lines containing {ref:SlotName}", () => {
+    const template =
+      "{assign:MainTank} Rend\nRef line: {ref:MainTank}\nOther line";
+    expect(extractCharacterLines(template, ["MainTank"])).toEqual([
+      "{assign:MainTank} Rend",
+      "Ref line: {ref:MainTank}",
+    ]);
+  });
+
+  it("matches case-insensitively", () => {
+    const template = "Tank: {assign:MAINTANK}";
+    expect(extractCharacterLines(template, ["maintank"])).toEqual([
+      "Tank: {assign:MAINTANK}",
+    ]);
+  });
+
+  it("matches slots with modifiers like {assign:SlotName:4}", () => {
+    const template = "Tank: {assign:MainTank:4:nocolor}";
+    expect(extractCharacterLines(template, ["MainTank"])).toEqual([
+      "Tank: {assign:MainTank:4:nocolor}",
+    ]);
+  });
+
+  it("matches slots with ref modifier {ref:SlotName:nocolor}", () => {
+    const template = "Ref: {ref:MainTank:nocolor}";
+    expect(extractCharacterLines(template, ["MainTank"])).toEqual([
+      "Ref: {ref:MainTank:nocolor}",
+    ]);
+  });
+
+  it("returns empty array when template is empty", () => {
+    expect(extractCharacterLines("", ["MainTank"])).toEqual([]);
+  });
+
+  it("returns empty array when slotNames is empty", () => {
+    expect(extractCharacterLines("Tank: {assign:MainTank}", [])).toEqual([]);
+  });
+
+  it("only returns lines containing the specified slots", () => {
+    const template = "MT: {assign:MainTank}\nOT: {assign:OffTank}";
+    expect(extractCharacterLines(template, ["MainTank"])).toEqual([
+      "MT: {assign:MainTank}",
+    ]);
+  });
+
+  it("returns a line containing any of multiple specified slots", () => {
+    const template =
+      "{assign:MainTank} and {assign:OffTank} on same line\nUnrelated line";
+    expect(extractCharacterLines(template, ["MainTank", "OffTank"])).toEqual([
+      "{assign:MainTank} and {assign:OffTank} on same line",
+    ]);
+  });
+
+  it("does not return lines with similar but non-matching slot names", () => {
+    const template = "MT: {assign:MainTankBackup}\nOT: {assign:MainTank}";
+    expect(extractCharacterLines(template, ["MainTank"])).toEqual([
+      "OT: {assign:MainTank}",
+    ]);
+  });
+});

--- a/src/lib/aa-template.ts
+++ b/src/lib/aa-template.ts
@@ -300,15 +300,45 @@ export function extractCharacterLines(
   if (!template || slotNames.length === 0) return [];
 
   const lowerNames = slotNames.map((n) => n.toLowerCase());
+  const lines = template.split("\n");
 
-  return template.split("\n").filter((line) => {
-    const lower = line.toLowerCase();
-    return lowerNames.some(
-      (name) =>
-        lower.includes(`{assign:${name}}`) ||
-        lower.includes(`{assign:${name}:`) ||
-        lower.includes(`{ref:${name}}`) ||
-        lower.includes(`{ref:${name}:`),
-    );
-  });
+  // First pass: lines that directly reference the character's slots.
+  const matched = new Set(
+    lines.filter((line) => {
+      const lower = line.toLowerCase();
+      return lowerNames.some(
+        (name) =>
+          lower.includes(`{assign:${name}}`) ||
+          lower.includes(`{assign:${name}:`) ||
+          lower.includes(`{ref:${name}}`) ||
+          lower.includes(`{ref:${name}:`),
+      );
+    }),
+  );
+
+  // Second pass: if any matched line contains a {ref:SlotX}, also include the
+  // line(s) that define SlotX via {assign:SlotX} so the renderer can resolve it.
+  const referencedSlots = new Set<string>();
+  for (const line of matched) {
+    for (const m of line.toLowerCase().matchAll(/\{ref:([^}:]+)/g)) {
+      referencedSlots.add(m[1]!);
+    }
+  }
+  if (referencedSlots.size > 0) {
+    for (const line of lines) {
+      if (matched.has(line)) continue;
+      const lower = line.toLowerCase();
+      for (const slot of referencedSlots) {
+        if (
+          lower.includes(`{assign:${slot}}`) ||
+          lower.includes(`{assign:${slot}:`)
+        ) {
+          matched.add(line);
+          break;
+        }
+      }
+    }
+  }
+
+  return lines.filter((line) => matched.has(line));
 }

--- a/src/lib/aa-template.ts
+++ b/src/lib/aa-template.ts
@@ -288,3 +288,27 @@ export function getSlotDefinitions(template: string): AASlotDefinition[] {
 
   return definitions;
 }
+
+/**
+ * Extract template lines that contain an {assign:} or {ref:} tag for any of
+ * the given slot names. Used to build the per-character assignment summary.
+ */
+export function extractCharacterLines(
+  template: string,
+  slotNames: string[],
+): string[] {
+  if (!template || slotNames.length === 0) return [];
+
+  const lowerNames = slotNames.map((n) => n.toLowerCase());
+
+  return template.split("\n").filter((line) => {
+    const lower = line.toLowerCase();
+    return lowerNames.some(
+      (name) =>
+        lower.includes(`{assign:${name}}`) ||
+        lower.includes(`{assign:${name}:`) ||
+        lower.includes(`{ref:${name}}`) ||
+        lower.includes(`{ref:${name}:`),
+    );
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: "node",
+  },
+});


### PR DESCRIPTION
When viewing a public raid plan as a specific character, a new panel appears below the header showing that character's AA assignments across all encounters at a glance.

### Features + updates

- Summary sentence: "_CharacterName_ has assignments in EncounterA, EncounterB, EncounterC, and N more encounters"
- Collapsible detail list showing each encounter and role, in two compact left-aligned columns
- Hovering an encounter row shows a tooltip with the fully rendered AA line — class colors, icons, and all names resolved
- Clicking any encounter row jumps directly to that encounter's tab
- Panel is hidden when the selected character has no assignments or isn't on the roster

### Technical details

- Zero new API calls — all data derived client-side from existing _getPublicById_ response
- New _extractCharacterLines_ utility in _aa-template.ts_ filters template lines to only those relevant to the character; includes a second pass to pull in ref-dependency lines so _\{ref:\}_ tags resolve correctly in the tooltip
- Vitest added for unit testing _extractCharacterLines_ (11 tests)