### PR TITLE
Fix attendance widget lockout week resetting at UTC instead of ET midnight

### DIFF
--- a/drizzle/0022_fix-lockout-views-et-timezone.sql
+++ b/drizzle/0022_fix-lockout-views-et-timezone.sql
@@ -1,0 +1,9 @@
+-- Custom SQL migration file, put your code below! --
+
+-- Set database timezone to Eastern Time so CURRENT_DATE in views reflects ET midnight,
+-- aligning lockout week boundaries with the WoW Classic reset (Tuesday midnight ET).
+DO $$
+BEGIN
+  EXECUTE format('ALTER DATABASE %I SET timezone TO %L', current_database(), 'America/New_York');
+END;
+$$;

--- a/drizzle/meta/0022_snapshot.json
+++ b/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,2625 @@
+{
+  "id": "4176e698-3b37-455a-9734-c90b56976bf4",
+  "prevId": "94551e5f-565d-419c-bef7-dc1847be1858",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "columnsFrom": ["user_id"],
+          "tableTo": "auth_user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "auth_account_provider_provider_account_id_pk": {
+          "name": "auth_account_provider_provider_account_id_pk",
+          "columns": ["provider", "provider_account_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_spells": {
+      "name": "character_spells",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_spell_id": {
+          "name": "recipe_spell_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_spells_character_id_character_character_id_fk": {
+          "name": "character_spells_character_id_character_character_id_fk",
+          "tableFrom": "character_spells",
+          "columnsFrom": ["character_id"],
+          "tableTo": "character",
+          "columnsTo": ["character_id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "character_spells_recipe_spell_id_recipes_recipe_spell_id_fk": {
+          "name": "character_spells_recipe_spell_id_recipes_recipe_spell_id_fk",
+          "tableFrom": "character_spells",
+          "columnsFrom": ["recipe_spell_id"],
+          "tableTo": "recipes",
+          "columnsTo": ["recipe_spell_id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "character_spells_created_by_auth_user_id_fk": {
+          "name": "character_spells_created_by_auth_user_id_fk",
+          "tableFrom": "character_spells",
+          "columnsFrom": ["created_by"],
+          "tableTo": "auth_user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "character_spells_updated_by_auth_user_id_fk": {
+          "name": "character_spells_updated_by_auth_user_id_fk",
+          "tableFrom": "character_spells",
+          "columnsFrom": ["updated_by"],
+          "tableTo": "auth_user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {
+        "character_spells_character_id_recipe_spell_id_pk": {
+          "name": "character_spells_character_id_recipe_spell_id_pk",
+          "columns": ["character_id", "recipe_spell_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character": {
+      "name": "character",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server": {
+          "name": "server",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unknown'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_detail": {
+          "name": "class_detail",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_character_id": {
+          "name": "primary_character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "type": "stored",
+            "as": "(\"character\".\"character_id\" = COALESCE (\"character\".\"primary_character_id\", 0))\n                 OR\n                 \"character\".\"primary_character_id\"\n                 IS\n                 NULL"
+          }
+        },
+        "is_ignored": {
+          "name": "is_ignored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_via": {
+          "name": "created_via",
+          "type": "created_via",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_via": {
+          "name": "updated_via",
+          "type": "updated_via",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_created_by_auth_user_id_fk": {
+          "name": "character_created_by_auth_user_id_fk",
+          "tableFrom": "character",
+          "columnsFrom": ["created_by"],
+          "tableTo": "auth_user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "character__primary_character_id_fk": {
+          "name": "character__primary_character_id_fk",
+          "tableFrom": "character",
+          "columnsFrom": ["primary_character_id"],
+          "tableTo": "character",
+          "columnsTo": ["character_id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_bench_map": {
+      "name": "raid_bench_map",
+      "schema": "",
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_bench_map__raid_id_idx": {
+          "name": "raid_bench_map__raid_id_idx",
+          "columns": [
+            {
+              "expression": "raid_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "raid_bench_map__character_id_idx": {
+          "name": "raid_bench_map__character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "raid_bench_map_raid_id_raid_raid_id_fk": {
+          "name": "raid_bench_map_raid_id_raid_raid_id_fk",
+          "tableFrom": "raid_bench_map",
+          "columnsFrom": ["raid_id"],
+          "tableTo": "raid",
+          "columnsTo": ["raid_id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "raid_bench_map_character_id_character_character_id_fk": {
+          "name": "raid_bench_map_character_id_character_character_id_fk",
+          "tableFrom": "raid_bench_map",
+          "columnsFrom": ["character_id"],
+          "tableTo": "character",
+          "columnsTo": ["character_id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "raid_bench_map_created_by_auth_user_id_fk": {
+          "name": "raid_bench_map_created_by_auth_user_id_fk",
+          "tableFrom": "raid_bench_map",
+          "columnsFrom": ["created_by"],
+          "tableTo": "auth_user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {
+        "raid_bench_map_raid_id_character_id_pk": {
+          "name": "raid_bench_map_raid_id_character_id_pk",
+          "columns": ["raid_id", "character_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_log_attendee_map": {
+      "name": "raid_log_attendee_map",
+      "schema": "",
+      "columns": {
+        "raid_log_id": {
+          "name": "raid_log_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ignored": {
+          "name": "is_ignored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raid_log_attendee_map__raid_log_id_idx": {
+          "name": "raid_log_attendee_map__raid_log_id_idx",
+          "columns": [
+            {
+              "expression": "raid_log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "raid_log_attendee_map__character_id_idx": {
+          "name": "raid_log_attendee_map__character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "raid_log_attendee_map_raid_log_id_raid_log_raid_log_id_fk": {
+          "name": "raid_log_attendee_map_raid_log_id_raid_log_raid_log_id_fk",
+          "tableFrom": "raid_log_attendee_map",
+          "columnsFrom": ["raid_log_id"],
+          "tableTo": "raid_log",
+          "columnsTo": ["raid_log_id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "raid_log_attendee_map_character_id_character_character_id_fk": {
+          "name": "raid_log_attendee_map_character_id_character_character_id_fk",
+          "tableFrom": "raid_log_attendee_map",
+          "columnsFrom": ["character_id"],
+          "tableTo": "character",
+          "columnsTo": ["character_id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "raid_log_attendee_map_raid_log_id_character_id_pk": {
+          "name": "raid_log_attendee_map_raid_log_id_character_id_pk",
+          "columns": ["raid_log_id", "character_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_log": {
+      "name": "raid_log",
+      "schema": "",
+      "columns": {
+        "raid_log_id": {
+          "name": "raid_log_id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raid_id": {
+          "name": "raid_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone": {
+          "name": "zone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "killCount": {
+          "name": "killCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "type": "stored",
+            "as": "cardinality\n          (\"raid_log\".\"kills\")"
+          }
+        },
+        "start_time_utc": {
+          "name": "start_time_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time_utc": {
+          "name": "end_time_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_log__raid_log_id_idx": {
+          "name": "raid_log__raid_log_id_idx",
+          "columns": [
+            {
+              "expression": "raid_log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "raid_log__discord_message_id_idx": {
+          "name": "raid_log__discord_message_id_idx",
+          "columns": [
+            {
+              "expression": "discord_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "raid_log_raid_id_raid_raid_id_fk": {
+          "name": "raid_log_raid_id_raid_raid_id_fk",
+          "tableFrom": "raid_log",
+          "columnsFrom": ["raid_id"],
+          "tableTo": "raid",
+          "columnsTo": ["raid_id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "raid_log_created_by_auth_user_id_fk": {
+          "name": "raid_log_created_by_auth_user_id_fk",
+          "tableFrom": "raid_log",
+          "columnsFrom": ["created_by"],
+          "tableTo": "auth_user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_character": {
+      "name": "raid_plan_character",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raid_plan_id": {
+          "name": "raid_plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "write_in_class": {
+          "name": "write_in_class",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_group": {
+          "name": "default_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_position": {
+          "name": "default_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_character__raid_plan_id_idx": {
+          "name": "raid_plan_character__raid_plan_id_idx",
+          "columns": [
+            {
+              "expression": "raid_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "raid_plan_character__character_id_idx": {
+          "name": "raid_plan_character__character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_character_raid_plan_id_raid_plan_id_fk": {
+          "name": "raid_plan_character_raid_plan_id_raid_plan_id_fk",
+          "tableFrom": "raid_plan_character",
+          "columnsFrom": ["raid_plan_id"],
+          "tableTo": "raid_plan",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "raid_plan_character_character_id_character_character_id_fk": {
+          "name": "raid_plan_character_character_id_character_character_id_fk",
+          "tableFrom": "raid_plan_character",
+          "columnsFrom": ["character_id"],
+          "tableTo": "character",
+          "columnsTo": ["character_id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_encounter_aa_slot": {
+      "name": "raid_plan_encounter_aa_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "encounter_id": {
+          "name": "encounter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raid_plan_id": {
+          "name": "raid_plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_character_id": {
+          "name": "plan_character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_name": {
+          "name": "slot_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "aa_slot__encounter_id_idx": {
+          "name": "aa_slot__encounter_id_idx",
+          "columns": [
+            {
+              "expression": "encounter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "aa_slot__raid_plan_id_idx": {
+          "name": "aa_slot__raid_plan_id_idx",
+          "columns": [
+            {
+              "expression": "raid_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "aa_slot__plan_character_id_idx": {
+          "name": "aa_slot__plan_character_id_idx",
+          "columns": [
+            {
+              "expression": "plan_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_encounter_aa_slot_encounter_id_raid_plan_encounter_id_fk": {
+          "name": "raid_plan_encounter_aa_slot_encounter_id_raid_plan_encounter_id_fk",
+          "tableFrom": "raid_plan_encounter_aa_slot",
+          "columnsFrom": ["encounter_id"],
+          "tableTo": "raid_plan_encounter",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "raid_plan_encounter_aa_slot_raid_plan_id_raid_plan_id_fk": {
+          "name": "raid_plan_encounter_aa_slot_raid_plan_id_raid_plan_id_fk",
+          "tableFrom": "raid_plan_encounter_aa_slot",
+          "columnsFrom": ["raid_plan_id"],
+          "tableTo": "raid_plan",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "raid_plan_encounter_aa_slot_plan_character_id_raid_plan_character_id_fk": {
+          "name": "raid_plan_encounter_aa_slot_plan_character_id_raid_plan_character_id_fk",
+          "tableFrom": "raid_plan_encounter_aa_slot",
+          "columnsFrom": ["plan_character_id"],
+          "tableTo": "raid_plan_character",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_encounter_assignment": {
+      "name": "raid_plan_encounter_assignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "encounter_id": {
+          "name": "encounter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_character_id": {
+          "name": "plan_character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_encounter_assignment__encounter_id_idx": {
+          "name": "raid_plan_encounter_assignment__encounter_id_idx",
+          "columns": [
+            {
+              "expression": "encounter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "raid_plan_encounter_assignment__plan_character_id_idx": {
+          "name": "raid_plan_encounter_assignment__plan_character_id_idx",
+          "columns": [
+            {
+              "expression": "plan_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_encounter_assignment_encounter_id_raid_plan_encounter_id_fk": {
+          "name": "raid_plan_encounter_assignment_encounter_id_raid_plan_encounter_id_fk",
+          "tableFrom": "raid_plan_encounter_assignment",
+          "columnsFrom": ["encounter_id"],
+          "tableTo": "raid_plan_encounter",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "raid_plan_encounter_assignment_plan_character_id_raid_plan_character_id_fk": {
+          "name": "raid_plan_encounter_assignment_plan_character_id_raid_plan_character_id_fk",
+          "tableFrom": "raid_plan_encounter_assignment",
+          "columnsFrom": ["plan_character_id"],
+          "tableTo": "raid_plan_character",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_encounter_group": {
+      "name": "raid_plan_encounter_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raid_plan_id": {
+          "name": "raid_plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_encounter_group__raid_plan_id_idx": {
+          "name": "raid_plan_encounter_group__raid_plan_id_idx",
+          "columns": [
+            {
+              "expression": "raid_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_encounter_group_raid_plan_id_raid_plan_id_fk": {
+          "name": "raid_plan_encounter_group_raid_plan_id_raid_plan_id_fk",
+          "tableFrom": "raid_plan_encounter_group",
+          "columnsFrom": ["raid_plan_id"],
+          "tableTo": "raid_plan",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_encounter": {
+      "name": "raid_plan_encounter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raid_plan_id": {
+          "name": "raid_plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encounter_key": {
+          "name": "encounter_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_name": {
+          "name": "encounter_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "use_default_groups": {
+          "name": "use_default_groups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "aa_template": {
+          "name": "aa_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_custom_aa": {
+          "name": "use_custom_aa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_encounter__raid_plan_id_idx": {
+          "name": "raid_plan_encounter__raid_plan_id_idx",
+          "columns": [
+            {
+              "expression": "raid_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "raid_plan_encounter__group_id_idx": {
+          "name": "raid_plan_encounter__group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_encounter_raid_plan_id_raid_plan_id_fk": {
+          "name": "raid_plan_encounter_raid_plan_id_raid_plan_id_fk",
+          "tableFrom": "raid_plan_encounter",
+          "columnsFrom": ["raid_plan_id"],
+          "tableTo": "raid_plan",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "raid_plan_encounter_group_id_raid_plan_encounter_group_id_fk": {
+          "name": "raid_plan_encounter_group_id_raid_plan_encounter_group_id_fk",
+          "tableFrom": "raid_plan_encounter",
+          "columnsFrom": ["group_id"],
+          "tableTo": "raid_plan_encounter_group",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_presence": {
+      "name": "raid_plan_presence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raid_plan_id": {
+          "name": "raid_plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_session_id": {
+          "name": "client_session_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewing'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "raid_plan_presence__raid_plan_id_idx": {
+          "name": "raid_plan_presence__raid_plan_id_idx",
+          "columns": [
+            {
+              "expression": "raid_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "raid_plan_presence__user_id_idx": {
+          "name": "raid_plan_presence__user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "raid_plan_presence__last_seen_at_idx": {
+          "name": "raid_plan_presence__last_seen_at_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "raid_plan_presence__plan_session_idx": {
+          "name": "raid_plan_presence__plan_session_idx",
+          "columns": [
+            {
+              "expression": "raid_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_presence_raid_plan_id_raid_plan_id_fk": {
+          "name": "raid_plan_presence_raid_plan_id_raid_plan_id_fk",
+          "tableFrom": "raid_plan_presence",
+          "columnsFrom": ["raid_plan_id"],
+          "tableTo": "raid_plan",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "raid_plan_presence_user_id_auth_user_id_fk": {
+          "name": "raid_plan_presence_user_id_auth_user_id_fk",
+          "tableFrom": "raid_plan_presence",
+          "columnsFrom": ["user_id"],
+          "tableTo": "auth_user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_template_encounter_group": {
+      "name": "raid_plan_template_encounter_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_template_encounter_group__template_id_idx": {
+          "name": "raid_plan_template_encounter_group__template_id_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_template_encounter_group_template_id_raid_plan_template_id_fk": {
+          "name": "raid_plan_template_encounter_group_template_id_raid_plan_template_id_fk",
+          "tableFrom": "raid_plan_template_encounter_group",
+          "columnsFrom": ["template_id"],
+          "tableTo": "raid_plan_template",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_template_encounter": {
+      "name": "raid_plan_template_encounter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encounter_key": {
+          "name": "encounter_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_name": {
+          "name": "encounter_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "aa_template": {
+          "name": "aa_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_template_encounter__template_id_idx": {
+          "name": "raid_plan_template_encounter__template_id_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "raid_plan_template_encounter__group_id_idx": {
+          "name": "raid_plan_template_encounter__group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_template_encounter_template_id_raid_plan_template_id_fk": {
+          "name": "raid_plan_template_encounter_template_id_raid_plan_template_id_fk",
+          "tableFrom": "raid_plan_template_encounter",
+          "columnsFrom": ["template_id"],
+          "tableTo": "raid_plan_template",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "raid_plan_template_encounter_group_id_raid_plan_template_encounter_group_id_fk": {
+          "name": "raid_plan_template_encounter_group_id_raid_plan_template_encounter_group_id_fk",
+          "tableFrom": "raid_plan_template_encounter",
+          "columnsFrom": ["group_id"],
+          "tableTo": "raid_plan_template_encounter_group",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_template": {
+      "name": "raid_plan_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone_name": {
+          "name": "zone_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_group_count": {
+          "name": "default_group_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "default_aa_template": {
+          "name": "default_aa_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_template__zone_id_idx": {
+          "name": "raid_plan_template__zone_id_idx",
+          "columns": [
+            {
+              "expression": "zone_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_template_created_by_auth_user_id_fk": {
+          "name": "raid_plan_template_created_by_auth_user_id_fk",
+          "tableFrom": "raid_plan_template",
+          "columnsFrom": ["created_by"],
+          "tableTo": "auth_user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan": {
+      "name": "raid_plan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raid_helper_event_id": {
+          "name": "raid_helper_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_aa_template": {
+          "name": "default_aa_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_default_aa": {
+          "name": "use_default_aa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan__raid_helper_event_id_idx": {
+          "name": "raid_plan__raid_helper_event_id_idx",
+          "columns": [
+            {
+              "expression": "raid_helper_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "raid_plan__event_id_idx": {
+          "name": "raid_plan__event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_event_id_raid_raid_id_fk": {
+          "name": "raid_plan_event_id_raid_raid_id_fk",
+          "tableFrom": "raid_plan",
+          "columnsFrom": ["event_id"],
+          "tableTo": "raid",
+          "columnsTo": ["raid_id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "raid_plan_created_by_auth_user_id_fk": {
+          "name": "raid_plan_created_by_auth_user_id_fk",
+          "tableFrom": "raid_plan",
+          "columnsFrom": ["created_by"],
+          "tableTo": "auth_user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "raid_plan_updated_by_auth_user_id_fk": {
+          "name": "raid_plan_updated_by_auth_user_id_fk",
+          "tableFrom": "raid_plan",
+          "columnsFrom": ["updated_by"],
+          "tableTo": "auth_user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid": {
+      "name": "raid",
+      "schema": "",
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_weight": {
+          "name": "attendance_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "zone": {
+          "name": "zone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid__raid_id_idx": {
+          "name": "raid__raid_id_idx",
+          "columns": [
+            {
+              "expression": "raid_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "raid_created_by_auth_user_id_fk": {
+          "name": "raid_created_by_auth_user_id_fk",
+          "tableFrom": "raid",
+          "columnsFrom": ["created_by"],
+          "tableTo": "auth_user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "raid_updated_by_auth_user_id_fk": {
+          "name": "raid_updated_by_auth_user_id_fk",
+          "tableFrom": "raid",
+          "columnsFrom": ["updated_by"],
+          "tableTo": "auth_user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipes": {
+      "name": "recipes",
+      "schema": "",
+      "columns": {
+        "recipe_spell_id": {
+          "name": "recipe_spell_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profession": {
+          "name": "profession",
+          "type": "profession",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe": {
+          "name": "recipe",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_common": {
+          "name": "is_common",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recipes_created_by_auth_user_id_fk": {
+          "name": "recipes_created_by_auth_user_id_fk",
+          "tableFrom": "recipes",
+          "columnsFrom": ["created_by"],
+          "tableTo": "auth_user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "recipes_updated_by_auth_user_id_fk": {
+          "name": "recipes_updated_by_auth_user_id_fk",
+          "tableFrom": "recipes",
+          "columnsFrom": ["updated_by"],
+          "tableTo": "auth_user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "columnsFrom": ["user_id"],
+          "tableTo": "auth_user",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_raid_manager": {
+          "name": "is_raid_manager",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_token": {
+          "name": "api_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user__id_idx": {
+          "name": "user__id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user__api_token_idx": {
+          "name": "user__api_token_idx",
+          "columns": [
+            {
+              "expression": "api_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification_token": {
+      "name": "auth_verification_token",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "auth_verification_token_identifier_token_pk": {
+          "name": "auth_verification_token_identifier_token_pk",
+          "columns": ["identifier", "token"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.created_via": {
+      "name": "created_via",
+      "schema": "public",
+      "values": ["ui", "wcl_raid_log_import"]
+    },
+    "public.profession": {
+      "name": "profession",
+      "schema": "public",
+      "values": [
+        "Alchemy",
+        "Blacksmithing",
+        "Enchanting",
+        "Engineering",
+        "Tailoring",
+        "Leatherworking",
+        "Cooking"
+      ]
+    },
+    "public.updated_via": {
+      "name": "updated_via",
+      "schema": "public",
+      "values": ["ui", "wcl_raid_log_import"]
+    }
+  },
+  "schemas": {},
+  "views": {
+    "views.all_raids_current_lockout": {
+      "name": "all_raids_current_lockout",
+      "schema": "views",
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_weight": {
+          "name": "attendance_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "zone": {
+          "name": "zone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "materialized": false,
+      "isExisting": true
+    },
+    "views.primary_raid_attendance_l6lockoutwk": {
+      "name": "primary_raid_attendance_l6lockoutwk",
+      "schema": "views",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weighted_attendance": {
+          "name": "weighted_attendance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weighted_raid_total": {
+          "name": "weighted_raid_total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weighted_attendance_pct": {
+          "name": "weighted_attendance_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "materialized": false,
+      "isExisting": true
+    },
+    "views.primary_raid_attendee_and_bench_map": {
+      "name": "primary_raid_attendee_and_bench_map",
+      "schema": "views",
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_character_id": {
+          "name": "primary_character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_character_ids": {
+          "name": "all_character_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendee_or_bench": {
+          "name": "attendee_or_bench",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_characters": {
+          "name": "all_characters",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raid_log_ids": {
+          "name": "raid_log_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "materialized": false,
+      "isExisting": true
+    },
+    "views.primary_raid_attendee_map": {
+      "name": "primary_raid_attendee_map",
+      "schema": "views",
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_character_id": {
+          "name": "primary_character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attending_character_ids": {
+          "name": "attending_character_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "materialized": false,
+      "isExisting": true
+    },
+    "views.primary_raid_bench_map": {
+      "name": "primary_raid_bench_map",
+      "schema": "views",
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_character_id": {
+          "name": "primary_character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bench_character_ids": {
+          "name": "bench_character_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "materialized": false,
+      "isExisting": true
+    },
+    "views.report_dates": {
+      "name": "report_dates",
+      "schema": "views",
+      "columns": {
+        "report_period_start": {
+          "name": "report_period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_period_end": {
+          "name": "report_period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "materialized": false,
+      "isExisting": true
+    },
+    "views.tracked_raids_current_lockout": {
+      "name": "tracked_raids_current_lockout",
+      "schema": "views",
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_weight": {
+          "name": "attendance_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "zone": {
+          "name": "zone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "materialized": false,
+      "isExisting": true
+    },
+    "views.tracked_raids_l6lockoutwk": {
+      "name": "tracked_raids_l6lockoutwk",
+      "schema": "views",
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_weight": {
+          "name": "attendance_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "zone": {
+          "name": "zone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lockout_week": {
+          "name": "lockout_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "materialized": false,
+      "isExisting": true
+    }
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1777177429445,
       "tag": "0021_flat_carmella_unuscione",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1777343397698,
+      "tag": "0022_fix-lockout-views-et-timezone",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Fixes the dashboard attendance widget where % attendance and week checkboxes would fall out of sync — the percentage was already flipping to the new lockout period while the week summary had not yet caught up.

### Fixes

- Both the attendance percentage and week checkboxes now reset at the same time: Tuesday midnight ET

### Technical details

- The reporting SQL views used PostgreSQL's _CURRENT_DATE_ (UTC), while the week checkbox logic already used Eastern Time — causing up to a 5-hour gap around the lockout boundary
- Single migration (_0022_fix-lockout-views-et-timezone.sql_) sets the database timezone to _America/New_York_, so _CURRENT_DATE_ in all views now reflects ET automatically