### PR TITLE
Responsive assignment list in character summary panel

### DIFF
--- a/src/components/raid-planner/character-summary-panel.tsx
+++ b/src/components/raid-planner/character-summary-panel.tsx
@@ -91,11 +91,11 @@ export function CharacterSummaryPanel({
         </button>
       </div>
 
-      {/* Encounter list — single column */}
+      {/* Encounter list — single column on mobile, two columns on larger screens */}
       {showDetails && encounterSummaries.length > 0 && (
         <div className="border-t border-border px-3 py-2">
           <TooltipProvider delayDuration={300}>
-            <div className="flex flex-col">
+            <div className="grid grid-cols-1 gap-x-8 sm:grid-cols-2">
               {encounterSummaries.map((summary) => (
                 <Tooltip key={summary.encounterId}>
                   <TooltipTrigger asChild>

--- a/src/components/raid-planner/character-summary-panel.tsx
+++ b/src/components/raid-planner/character-summary-panel.tsx
@@ -91,71 +91,59 @@ export function CharacterSummaryPanel({
         </button>
       </div>
 
-      {/* Encounter list — two compact columns, left-aligned */}
+      {/* Encounter list — single column */}
       {showDetails && encounterSummaries.length > 0 && (
         <div className="border-t border-border px-3 py-2">
           <TooltipProvider delayDuration={300}>
-            <div className="flex items-start gap-x-8">
-              {[
-                encounterSummaries.slice(
-                  0,
-                  Math.ceil(encounterSummaries.length / 2),
-                ),
-                encounterSummaries.slice(
-                  Math.ceil(encounterSummaries.length / 2),
-                ),
-              ].map((col, ci) => (
-                <div key={ci} className="flex flex-col">
-                  {col.map((summary) => (
-                    <Tooltip key={summary.encounterId}>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          onClick={() => onEncounterClick(summary.encounterId)}
-                          className="flex items-center gap-2 py-0.5 text-left text-sm transition-opacity hover:opacity-70"
-                        >
-                          <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground/50" />
-                          <span className="shrink-0 font-semibold text-foreground">
-                            {summary.encounterName}
+            <div className="flex flex-col">
+              {encounterSummaries.map((summary) => (
+                <Tooltip key={summary.encounterId}>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={() => onEncounterClick(summary.encounterId)}
+                      className="flex items-center gap-2 py-0.5 text-left text-sm transition-opacity hover:opacity-70"
+                    >
+                      <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground/50" />
+                      <span className="shrink-0 font-semibold text-foreground">
+                        {summary.encounterName}
+                      </span>
+                      <div className="flex flex-wrap gap-1">
+                        {summary.slotNames.map((name) => (
+                          <span
+                            key={name}
+                            className="inline-block rounded border border-purple-500/25 bg-purple-500/10 px-1 text-xs font-medium text-purple-300"
+                          >
+                            {name}
                           </span>
-                          <div className="flex flex-wrap gap-1">
-                            {summary.slotNames.map((name) => (
-                              <span
-                                key={name}
-                                className="inline-block rounded border border-purple-500/25 bg-purple-500/10 px-1 text-xs font-medium text-purple-300"
-                              >
-                                {name}
-                              </span>
-                            ))}
-                          </div>
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent
-                        side="right"
-                        className="w-auto max-w-sm bg-card p-0 text-foreground shadow-xl"
-                      >
-                        <AATemplateRenderer
-                          template={summary.template}
-                          encounterId={
-                            summary.encounterId !== "default"
-                              ? summary.contextId
-                              : undefined
-                          }
-                          raidPlanId={
-                            summary.encounterId === "default"
-                              ? summary.contextId
-                              : undefined
-                          }
-                          characters={allCharacters}
-                          slotAssignments={summary.slotAssignments}
-                          disabled
-                          hideUnassigned
-                          skipDndContext
-                        />
-                      </TooltipContent>
-                    </Tooltip>
-                  ))}
-                </div>
+                        ))}
+                      </div>
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent
+                    side="right"
+                    className="w-auto max-w-sm bg-card p-0 text-foreground shadow-xl"
+                  >
+                    <AATemplateRenderer
+                      template={summary.template}
+                      encounterId={
+                        summary.encounterId !== "default"
+                          ? summary.contextId
+                          : undefined
+                      }
+                      raidPlanId={
+                        summary.encounterId === "default"
+                          ? summary.contextId
+                          : undefined
+                      }
+                      characters={allCharacters}
+                      slotAssignments={summary.slotAssignments}
+                      disabled
+                      hideUnassigned
+                      skipDndContext
+                    />
+                  </TooltipContent>
+                </Tooltip>
               ))}
             </div>
           </TooltipProvider>


### PR DESCRIPTION
The character assignment list in the raid plan summary panel now stacks into a single column on smaller/mobile screens.

### Fixes

- Assignment list in the character summary panel is single-column on mobile and two-column on larger screens


---
_Generated by [Claude Code](https://claude.ai/code/session_0131e5daHq9BcXhEhibntMA7)_