### PR TITLE
Remove Wraith Blade from restricted Naxx items list

### DIFF
--- a/src/server/services/softres-rules.ts
+++ b/src/server/services/softres-rules.ts
@@ -8,7 +8,8 @@ import type { SoftResRule, RuleEvaluationContext } from "./softres-rule-types";
  * Restricted Naxx items requiring 50%+ raid attendance
  */
 const RESTRICTED_NAXX_ITEMS = new Set([
-  22807, // Wraith Blade
+  // // Removed 4/29/2026
+  // 22807, // Wraith Blade
   22954, // Kiss of the Spider
   23046, // The Restrained Essence of Sapphiron
   23047, // Eye of the Dead


### PR DESCRIPTION
Remove Wraith Blade (item ID 22807) from the restricted Naxx items list that requires 50%+ raid attendance.

### Features + updates

- Wraith Blade is no longer subject to the 50%+ raid attendance restriction

### Fixes

- N/A

### Technical details

- Commented out item ID 22807 from the `RESTRICTED_NAXX_ITEMS` set in `src/server/services/softres-rules.ts`
- Other restricted items (Kiss of the Spider, The Restrained Essence of Sapphiron, Eye of the Dead) remain unchanged
- No changes to rule evaluation logic or other functionality

https://claude.ai/code/session_016TK7BkEQUD1Ni5wF34xnkm