### PR TITLE
Tune Supabase connection pool for serverless

### DIFF
--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -19,6 +19,7 @@ const conn =
     max: 3,
     connect_timeout: 10,
     max_lifetime: 60 * 5,
+    idle_timeout: 20,
   });
 if (env.NODE_ENV !== "production") globalForDb.conn = conn;
 


### PR DESCRIPTION
Improves connection handling between Vercel serverless functions and Supabase Session Pooler.

### Technical details

- Adds _idle_timeout: 20_ — connections are released back to the Session Pooler 20 seconds after the last query, rather than being held open indefinitely
- Prevents old deployment Lambda instances from holding connection slots open after Vercel cuts over to a new deployment