### PR TITLE
Pre-fill AA slots from returning raiders when cloning a plan

### DIFF
--- a/src/components/raid-planner/aa-carry-forward-dialog.tsx
+++ b/src/components/raid-planner/aa-carry-forward-dialog.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { Users, Zap } from "lucide-react";
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "~/components/ui/dialog";
+import { Skeleton } from "~/components/ui/skeleton";
+import { useToast } from "~/hooks/use-toast";
+import { api } from "~/trpc/react";
+
+interface AACarryForwardDialogProps {
+  open: boolean;
+  sourcePlanId: string;
+  targetPlanId: string;
+  sourcePlanName: string;
+  onComplete: (targetPlanId: string) => void;
+}
+
+export function AACarryForwardDialog({
+  open,
+  sourcePlanId,
+  targetPlanId,
+  sourcePlanName,
+  onComplete,
+}: AACarryForwardDialogProps) {
+  const { toast } = useToast();
+
+  const { data: preview, isLoading } =
+    api.raidPlan.previewAACarryForward.useQuery(
+      { sourcePlanId, targetPlanId },
+      { enabled: open },
+    );
+
+  const applyMutation = api.raidPlan.applyAACarryForward.useMutation({
+    onSuccess: (data) => {
+      toast({
+        title: "AA slots pre-filled",
+        description: `${data.slotsCreated} slot assignment${data.slotsCreated === 1 ? "" : "s"} carried forward.`,
+      });
+      onComplete(targetPlanId);
+    },
+    onError: (error) => {
+      toast({
+        title: "Failed to pre-fill slots",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const hasMatches = !isLoading && preview && preview.slotsToFill > 0;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen && !applyMutation.isPending) {
+          onComplete(targetPlanId);
+        }
+      }}
+    >
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Zap className="h-5 w-5" />
+            Pre-fill AA Slots
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="py-2 text-sm text-muted-foreground">
+          {isLoading ? (
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-4 w-1/2" />
+            </div>
+          ) : hasMatches ? (
+            <div className="flex items-start gap-2">
+              <Users className="mt-0.5 h-4 w-4 shrink-0 text-foreground" />
+              <span>
+                Found{" "}
+                <span className="font-semibold text-foreground">
+                  {preview.matchedCharacters} returning raider
+                  {preview.matchedCharacters === 1 ? "" : "s"}
+                </span>{" "}
+                from{" "}
+                <span className="font-medium text-foreground">
+                  {sourcePlanName}
+                </span>{" "}
+                —{" "}
+                <span className="font-semibold text-foreground">
+                  {preview.slotsToFill} AA slot
+                  {preview.slotsToFill === 1 ? "" : "s"}
+                </span>{" "}
+                ready to pre-fill.
+              </span>
+            </div>
+          ) : (
+            <p>
+              No returning raiders found from{" "}
+              <span className="font-medium text-foreground">
+                {sourcePlanName}
+              </span>
+              . AA slots will start empty.
+            </p>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button
+            variant="outline"
+            onClick={() => onComplete(targetPlanId)}
+            disabled={applyMutation.isPending}
+          >
+            Skip
+          </Button>
+          {hasMatches && (
+            <Button
+              onClick={() =>
+                applyMutation.mutate({ sourcePlanId, targetPlanId })
+              }
+              disabled={applyMutation.isPending}
+            >
+              {applyMutation.isPending ? "Pre-filling…" : "Pre-fill Slots"}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/raid-planner/raid-helper-import.tsx
+++ b/src/components/raid-planner/raid-helper-import.tsx
@@ -44,6 +44,7 @@ import {
   DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu";
 import { MatchReviewSheet } from "./match-review-sheet";
+import { AACarryForwardDialog } from "./aa-carry-forward-dialog";
 
 // Detect zone from event title
 function detectZoneFromTitle(title: string): string | null {
@@ -240,6 +241,11 @@ function CharacterMatchingDialog({
     null,
   );
   const [isReviewOpen, setIsReviewOpen] = useState(false);
+  const [pendingCarryForward, setPendingCarryForward] = useState<{
+    sourcePlanId: string;
+    targetPlanId: string;
+    sourcePlanName: string;
+  } | null>(null);
 
   // Default home server to user's primary character server
   const characterId = session?.user?.characterId;
@@ -344,7 +350,15 @@ function CharacterMatchingDialog({
   const createPlanMutation = api.raidPlan.create.useMutation({
     onSuccess: (data) => {
       onOpenChange(false);
-      router.push(`/raid-manager/raid-planner/${data.id}`);
+      if (cloneFromPlanId) {
+        setPendingCarryForward({
+          sourcePlanId: cloneFromPlanId,
+          targetPlanId: data.id,
+          sourcePlanName: cloneFromPlanName ?? "Previous Plan",
+        });
+      } else {
+        router.push(`/raid-manager/raid-planner/${data.id}`);
+      }
     },
     onError: (error) => {
       toast({
@@ -712,7 +726,6 @@ function CharacterMatchingDialog({
             </div>
 
             <div className="flex items-center gap-2">
-
               {/* Server selector */}
               <div className="flex items-center gap-2">
                 <label
@@ -831,6 +844,18 @@ function CharacterMatchingDialog({
           matchResults={matchResults}
         />
       ) : null}
+      {pendingCarryForward && (
+        <AACarryForwardDialog
+          open={true}
+          sourcePlanId={pendingCarryForward.sourcePlanId}
+          targetPlanId={pendingCarryForward.targetPlanId}
+          sourcePlanName={pendingCarryForward.sourcePlanName}
+          onComplete={(id) => {
+            setPendingCarryForward(null);
+            router.push(`/raid-manager/raid-planner/${id}`);
+          }}
+        />
+      )}
     </Dialog>
   );
 }

--- a/src/server/api/routers/raid-plan.ts
+++ b/src/server/api/routers/raid-plan.ts
@@ -2395,6 +2395,12 @@ export const raidPlanRouter = createTRPCRouter({
       }),
     )
     .query(async ({ ctx, input }) => {
+      // Pre-fetch source encounters for ID list (consistent with applyAACarryForward)
+      const sourceEncounters = await ctx.db
+        .select({ id: raidPlanEncounters.id })
+        .from(raidPlanEncounters)
+        .where(eq(raidPlanEncounters.raidPlanId, input.sourcePlanId));
+
       // Fetch source plan's AA slots with characterId
       const sourceSlots = await ctx.db
         .select({
@@ -2411,13 +2417,12 @@ export const raidPlanRouter = createTRPCRouter({
           and(
             or(
               eq(raidPlanEncounterAASlots.raidPlanId, input.sourcePlanId),
-              inArray(
-                raidPlanEncounterAASlots.encounterId,
-                ctx.db
-                  .select({ id: raidPlanEncounters.id })
-                  .from(raidPlanEncounters)
-                  .where(eq(raidPlanEncounters.raidPlanId, input.sourcePlanId)),
-              ),
+              sourceEncounters.length > 0
+                ? inArray(
+                    raidPlanEncounterAASlots.encounterId,
+                    sourceEncounters.map((e) => e.id),
+                  )
+                : sql`false`,
             ),
             isNotNull(raidPlanCharacters.characterId),
           ),
@@ -2590,12 +2595,10 @@ export const raidPlanRouter = createTRPCRouter({
       }
 
       if (slotsToInsert.length > 0) {
-        await ctx.db.insert(raidPlanEncounterAASlots).values(slotsToInsert);
-        await touchRaidPlanActor(
-          ctx.db,
-          input.targetPlanId,
-          ctx.session.user.id,
-        );
+        await ctx.db.transaction(async (tx) => {
+          await tx.insert(raidPlanEncounterAASlots).values(slotsToInsert);
+          await touchRaidPlanActor(tx, input.targetPlanId, ctx.session.user.id);
+        });
       }
 
       return { slotsCreated: slotsToInsert.length };

--- a/src/server/api/routers/raid-plan.ts
+++ b/src/server/api/routers/raid-plan.ts
@@ -12,6 +12,7 @@ import {
   gte,
   lt,
   sql,
+  isNotNull,
 } from "drizzle-orm";
 import {
   createTRPCRouter,
@@ -2379,6 +2380,225 @@ export const raidPlanRouter = createTRPCRouter({
           0,
         ),
       };
+    }),
+
+  /**
+   * Preview how many AA slot assignments would carry forward when cloning.
+   * Matches characters by characterId (write-ins are excluded).
+   * Matches encounters by encounterName.
+   */
+  previewAACarryForward: raidManagerProcedure
+    .input(
+      z.object({
+        sourcePlanId: z.string().uuid(),
+        targetPlanId: z.string().uuid(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      // Fetch source plan's AA slots with characterId
+      const sourceSlots = await ctx.db
+        .select({
+          characterId: raidPlanCharacters.characterId,
+          slotName: raidPlanEncounterAASlots.slotName,
+          encounterId: raidPlanEncounterAASlots.encounterId,
+        })
+        .from(raidPlanEncounterAASlots)
+        .innerJoin(
+          raidPlanCharacters,
+          eq(raidPlanEncounterAASlots.planCharacterId, raidPlanCharacters.id),
+        )
+        .where(
+          and(
+            or(
+              eq(raidPlanEncounterAASlots.raidPlanId, input.sourcePlanId),
+              inArray(
+                raidPlanEncounterAASlots.encounterId,
+                ctx.db
+                  .select({ id: raidPlanEncounters.id })
+                  .from(raidPlanEncounters)
+                  .where(eq(raidPlanEncounters.raidPlanId, input.sourcePlanId)),
+              ),
+            ),
+            isNotNull(raidPlanCharacters.characterId),
+          ),
+        );
+
+      if (sourceSlots.length === 0) {
+        return { matchedCharacters: 0, slotsToFill: 0 };
+      }
+
+      // Fetch target plan's named characters
+      const targetChars = await ctx.db
+        .select({
+          id: raidPlanCharacters.id,
+          characterId: raidPlanCharacters.characterId,
+        })
+        .from(raidPlanCharacters)
+        .where(
+          and(
+            eq(raidPlanCharacters.raidPlanId, input.targetPlanId),
+            isNotNull(raidPlanCharacters.characterId),
+          ),
+        );
+
+      const targetCharIds = new Set(
+        targetChars.map((c) => c.characterId).filter((id) => id !== null),
+      );
+
+      const matchedCharacterIds = new Set<number>();
+      let slotsToFill = 0;
+      for (const slot of sourceSlots) {
+        if (slot.characterId !== null && targetCharIds.has(slot.characterId)) {
+          matchedCharacterIds.add(slot.characterId);
+          slotsToFill++;
+        }
+      }
+
+      return {
+        matchedCharacters: matchedCharacterIds.size,
+        slotsToFill,
+      };
+    }),
+
+  /**
+   * Copy AA slot assignments from a source plan to a target plan for returning raiders.
+   * Characters matched by characterId; encounters matched by encounterName.
+   * Write-in characters (no characterId) are skipped.
+   */
+  applyAACarryForward: raidManagerProcedure
+    .input(
+      z.object({
+        sourcePlanId: z.string().uuid(),
+        targetPlanId: z.string().uuid(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      // 1. Fetch source encounters for name lookup
+      const sourceEncounters = await ctx.db
+        .select({
+          id: raidPlanEncounters.id,
+          encounterName: raidPlanEncounters.encounterName,
+        })
+        .from(raidPlanEncounters)
+        .where(eq(raidPlanEncounters.raidPlanId, input.sourcePlanId));
+
+      const sourceEncounterNames = new Map<string, string>(); // encounterId -> name
+      for (const enc of sourceEncounters) {
+        sourceEncounterNames.set(enc.id, enc.encounterName);
+      }
+
+      // 2. Fetch source AA slots with characterId
+      const sourceSlots = await ctx.db
+        .select({
+          characterId: raidPlanCharacters.characterId,
+          slotName: raidPlanEncounterAASlots.slotName,
+          sortOrder: raidPlanEncounterAASlots.sortOrder,
+          encounterId: raidPlanEncounterAASlots.encounterId,
+          raidPlanId: raidPlanEncounterAASlots.raidPlanId,
+        })
+        .from(raidPlanEncounterAASlots)
+        .innerJoin(
+          raidPlanCharacters,
+          eq(raidPlanEncounterAASlots.planCharacterId, raidPlanCharacters.id),
+        )
+        .where(
+          and(
+            or(
+              eq(raidPlanEncounterAASlots.raidPlanId, input.sourcePlanId),
+              sourceEncounters.length > 0
+                ? inArray(
+                    raidPlanEncounterAASlots.encounterId,
+                    sourceEncounters.map((e) => e.id),
+                  )
+                : sql`false`,
+            ),
+            isNotNull(raidPlanCharacters.characterId),
+          ),
+        );
+
+      if (sourceSlots.length === 0) return { slotsCreated: 0 };
+
+      // 3. Build target character map: characterId -> planCharacterId
+      const targetChars = await ctx.db
+        .select({
+          id: raidPlanCharacters.id,
+          characterId: raidPlanCharacters.characterId,
+        })
+        .from(raidPlanCharacters)
+        .where(
+          and(
+            eq(raidPlanCharacters.raidPlanId, input.targetPlanId),
+            isNotNull(raidPlanCharacters.characterId),
+          ),
+        );
+
+      const targetCharMap = new Map<number, string>(); // characterId -> planCharacterId
+      for (const char of targetChars) {
+        if (char.characterId !== null) {
+          targetCharMap.set(char.characterId, char.id);
+        }
+      }
+
+      // 4. Build target encounter map: encounterName -> encounterId
+      const targetEncounters = await ctx.db
+        .select({
+          id: raidPlanEncounters.id,
+          encounterName: raidPlanEncounters.encounterName,
+        })
+        .from(raidPlanEncounters)
+        .where(eq(raidPlanEncounters.raidPlanId, input.targetPlanId));
+
+      const targetEncounterMap = new Map<string, string>(); // name -> encounterId
+      for (const enc of targetEncounters) {
+        targetEncounterMap.set(enc.encounterName, enc.id);
+      }
+
+      // 5. Resolve slots to insert
+      const slotsToInsert: Array<{
+        encounterId: string | null;
+        raidPlanId: string | null;
+        planCharacterId: string;
+        slotName: string;
+        sortOrder: number;
+      }> = [];
+
+      for (const slot of sourceSlots) {
+        if (slot.characterId === null) continue;
+        const newPlanCharId = targetCharMap.get(slot.characterId);
+        if (!newPlanCharId) continue;
+
+        let targetEncounterId: string | null = null;
+        let targetRaidPlanId: string | null = null;
+
+        if (slot.encounterId !== null) {
+          const sourceName = sourceEncounterNames.get(slot.encounterId);
+          if (!sourceName) continue;
+          const targetEncId = targetEncounterMap.get(sourceName);
+          if (!targetEncId) continue;
+          targetEncounterId = targetEncId;
+        } else {
+          targetRaidPlanId = input.targetPlanId;
+        }
+
+        slotsToInsert.push({
+          encounterId: targetEncounterId,
+          raidPlanId: targetRaidPlanId,
+          planCharacterId: newPlanCharId,
+          slotName: slot.slotName,
+          sortOrder: slot.sortOrder,
+        });
+      }
+
+      if (slotsToInsert.length > 0) {
+        await ctx.db.insert(raidPlanEncounterAASlots).values(slotsToInsert);
+        await touchRaidPlanActor(
+          ctx.db,
+          input.targetPlanId,
+          ctx.session.user.id,
+        );
+      }
+
+      return { slotsCreated: slotsToInsert.length };
     }),
 
   /**


### PR DESCRIPTION
When cloning a raid plan, the app now detects returning raiders and offers to carry forward their AA slot assignments — saving manual re-assignment for repeat raids.

### Features + updates

- After a clone succeeds, a confirmation dialog appears showing how many returning raiders and AA slots were found
- Click "Pre-fill Slots" to carry forward all default and encounter-specific AA assignments for matching characters, or "Skip" to leave them empty
- Characters are matched by identity (named characters only; write-ins are excluded), encounters matched by name

### Technical details

- New _previewAACarryForward_ query and _applyAACarryForward_ mutation in the _raidPlan_ tRPC router
- New _AACarryForwardDialog_ component in _src/components/raid-planner/_
- Apply mutation is wrapped in a transaction; reads happen outside it