### PR TITLE
Templar Discord bot integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ DISCORD_WEBHOOK_PUBLIC_KEY=your_webhook_public_key
 # Discord Bot + Website communication
 TEMPLE_WEB_API_TOKEN="your_api_token"
 
+# AES-256-GCM key for encrypting API tokens (for Templar proxy). Generate with:
+# node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
+API_TOKEN_ENCRYPTION_KEY=
+
 # Raid-Helper Integration
 DISCORD_SERVER_ID=your_discord_server_id
 RAID_HELPER_API_KEY=your_raid_helper_api_key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,8 @@ src/
 - **Character Mapping**: Characters can be linked to a "primary" character for consolidated attendance
 - **Database Views**: Complex queries are materialized as views (e.g., `primary_raid_attendance_l6_lockout_wk`)
 - **Attendance Calculation**: 6-week rolling window based on raid dates and attendance weights
+- `templar_enabled` on `auth_user` — user opt-in for the Templar Discord bot proxy
+- `api_token_encrypted` on `auth_user` — AES-256-GCM encrypted copy of the API token, used exclusively by the proxy
 
 #### External API Integration
 
@@ -416,6 +418,7 @@ The website provides REST API endpoints for the Discord bot (separate repo):
 - `POST /api/discord/check-permissions` - Checks user permissions
 - `POST /api/discord/update-raid` - Updates existing raid data
 - `POST /api/discord/update-bench` - Updates raid bench assignments
+- `POST /api/discord/proxy/{discordId}` - Proxies a v1 API call on behalf of an opted-in user (requires `templarEnabled = true` on target user)
 - All require `Authorization: Bearer {TEMPLE_WEB_API_TOKEN}` header
 - Helper functions in `src/server/api/discord-helpers.ts`
 
@@ -428,6 +431,7 @@ The website provides a versioned public REST API at `/api/v1/`:
 - `GET /api/v1/characters` - Search/list characters (query params: `q`, `type`)
 - `GET /api/v1/characters/:id` - Character detail with family
 - `GET /api/v1/characters/:id/attendance` - 6-week rolling attendance
+- `PATCH /api/v1/me/templar` - Toggle Templar bot opt-in for the authenticated user (raid managers/admins only)
 
 **Auth:** Personal API tokens (`tera_<32-hex>`), generated from the profile page by raid managers and admins. Passed as `Authorization: Bearer <token>`. Tokens are stored as SHA-256 hashes in the DB.
 

--- a/drizzle/0023_tough_namorita.sql
+++ b/drizzle/0023_tough_namorita.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "auth_user" ADD COLUMN "api_token_encrypted" text;--> statement-breakpoint
+ALTER TABLE "auth_user" ADD COLUMN "templar_enabled" boolean DEFAULT false NOT NULL;

--- a/drizzle/0023_tough_namorita.sql
+++ b/drizzle/0023_tough_namorita.sql
@@ -1,2 +1,2 @@
-ALTER TABLE "auth_user" ADD COLUMN "api_token_encrypted" text;--> statement-breakpoint
-ALTER TABLE "auth_user" ADD COLUMN "templar_enabled" boolean DEFAULT false NOT NULL;
+ALTER TABLE "auth_user" ADD COLUMN IF NOT EXISTS "api_token_encrypted" text;--> statement-breakpoint
+ALTER TABLE "auth_user" ADD COLUMN IF NOT EXISTS "templar_enabled" boolean DEFAULT false NOT NULL;

--- a/drizzle/meta/0023_snapshot.json
+++ b/drizzle/meta/0023_snapshot.json
@@ -1,0 +1,2638 @@
+{
+  "id": "fe9f77cf-8948-4112-bafd-ca820cdc3338",
+  "prevId": "4176e698-3b37-455a-9734-c90b56976bf4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_account_user_id_auth_user_id_fk": {
+          "name": "auth_account_user_id_auth_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "auth_user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "auth_account_provider_provider_account_id_pk": {
+          "name": "auth_account_provider_provider_account_id_pk",
+          "columns": ["provider", "provider_account_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character_spells": {
+      "name": "character_spells",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_spell_id": {
+          "name": "recipe_spell_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_spells_character_id_character_character_id_fk": {
+          "name": "character_spells_character_id_character_character_id_fk",
+          "tableFrom": "character_spells",
+          "tableTo": "character",
+          "columnsFrom": ["character_id"],
+          "columnsTo": ["character_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "character_spells_recipe_spell_id_recipes_recipe_spell_id_fk": {
+          "name": "character_spells_recipe_spell_id_recipes_recipe_spell_id_fk",
+          "tableFrom": "character_spells",
+          "tableTo": "recipes",
+          "columnsFrom": ["recipe_spell_id"],
+          "columnsTo": ["recipe_spell_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "character_spells_created_by_auth_user_id_fk": {
+          "name": "character_spells_created_by_auth_user_id_fk",
+          "tableFrom": "character_spells",
+          "tableTo": "auth_user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "character_spells_updated_by_auth_user_id_fk": {
+          "name": "character_spells_updated_by_auth_user_id_fk",
+          "tableFrom": "character_spells",
+          "tableTo": "auth_user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "character_spells_character_id_recipe_spell_id_pk": {
+          "name": "character_spells_character_id_recipe_spell_id_pk",
+          "columns": ["character_id", "recipe_spell_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.character": {
+      "name": "character",
+      "schema": "",
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server": {
+          "name": "server",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Unknown'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_detail": {
+          "name": "class_detail",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_character_id": {
+          "name": "primary_character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\"character\".\"character_id\" = COALESCE (\"character\".\"primary_character_id\", 0))\n                 OR\n                 \"character\".\"primary_character_id\"\n                 IS\n                 NULL",
+            "type": "stored"
+          }
+        },
+        "is_ignored": {
+          "name": "is_ignored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_via": {
+          "name": "created_via",
+          "type": "created_via",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_via": {
+          "name": "updated_via",
+          "type": "updated_via",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "character_created_by_auth_user_id_fk": {
+          "name": "character_created_by_auth_user_id_fk",
+          "tableFrom": "character",
+          "tableTo": "auth_user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "character__primary_character_id_fk": {
+          "name": "character__primary_character_id_fk",
+          "tableFrom": "character",
+          "tableTo": "character",
+          "columnsFrom": ["primary_character_id"],
+          "columnsTo": ["character_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_bench_map": {
+      "name": "raid_bench_map",
+      "schema": "",
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_bench_map__raid_id_idx": {
+          "name": "raid_bench_map__raid_id_idx",
+          "columns": [
+            {
+              "expression": "raid_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_bench_map__character_id_idx": {
+          "name": "raid_bench_map__character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_bench_map_raid_id_raid_raid_id_fk": {
+          "name": "raid_bench_map_raid_id_raid_raid_id_fk",
+          "tableFrom": "raid_bench_map",
+          "tableTo": "raid",
+          "columnsFrom": ["raid_id"],
+          "columnsTo": ["raid_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_bench_map_character_id_character_character_id_fk": {
+          "name": "raid_bench_map_character_id_character_character_id_fk",
+          "tableFrom": "raid_bench_map",
+          "tableTo": "character",
+          "columnsFrom": ["character_id"],
+          "columnsTo": ["character_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "raid_bench_map_created_by_auth_user_id_fk": {
+          "name": "raid_bench_map_created_by_auth_user_id_fk",
+          "tableFrom": "raid_bench_map",
+          "tableTo": "auth_user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "raid_bench_map_raid_id_character_id_pk": {
+          "name": "raid_bench_map_raid_id_character_id_pk",
+          "columns": ["raid_id", "character_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_log_attendee_map": {
+      "name": "raid_log_attendee_map",
+      "schema": "",
+      "columns": {
+        "raid_log_id": {
+          "name": "raid_log_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_ignored": {
+          "name": "is_ignored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "raid_log_attendee_map__raid_log_id_idx": {
+          "name": "raid_log_attendee_map__raid_log_id_idx",
+          "columns": [
+            {
+              "expression": "raid_log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_log_attendee_map__character_id_idx": {
+          "name": "raid_log_attendee_map__character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_log_attendee_map_raid_log_id_raid_log_raid_log_id_fk": {
+          "name": "raid_log_attendee_map_raid_log_id_raid_log_raid_log_id_fk",
+          "tableFrom": "raid_log_attendee_map",
+          "tableTo": "raid_log",
+          "columnsFrom": ["raid_log_id"],
+          "columnsTo": ["raid_log_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_log_attendee_map_character_id_character_character_id_fk": {
+          "name": "raid_log_attendee_map_character_id_character_character_id_fk",
+          "tableFrom": "raid_log_attendee_map",
+          "tableTo": "character",
+          "columnsFrom": ["character_id"],
+          "columnsTo": ["character_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "raid_log_attendee_map_raid_log_id_character_id_pk": {
+          "name": "raid_log_attendee_map_raid_log_id_character_id_pk",
+          "columns": ["raid_log_id", "character_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_log": {
+      "name": "raid_log",
+      "schema": "",
+      "columns": {
+        "raid_log_id": {
+          "name": "raid_log_id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raid_id": {
+          "name": "raid_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone": {
+          "name": "zone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kills": {
+          "name": "kills",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "killCount": {
+          "name": "killCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "cardinality\n          (\"raid_log\".\"kills\")",
+            "type": "stored"
+          }
+        },
+        "start_time_utc": {
+          "name": "start_time_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time_utc": {
+          "name": "end_time_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_log__raid_log_id_idx": {
+          "name": "raid_log__raid_log_id_idx",
+          "columns": [
+            {
+              "expression": "raid_log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_log__discord_message_id_idx": {
+          "name": "raid_log__discord_message_id_idx",
+          "columns": [
+            {
+              "expression": "discord_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_log_raid_id_raid_raid_id_fk": {
+          "name": "raid_log_raid_id_raid_raid_id_fk",
+          "tableFrom": "raid_log",
+          "tableTo": "raid",
+          "columnsFrom": ["raid_id"],
+          "columnsTo": ["raid_id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "raid_log_created_by_auth_user_id_fk": {
+          "name": "raid_log_created_by_auth_user_id_fk",
+          "tableFrom": "raid_log",
+          "tableTo": "auth_user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_character": {
+      "name": "raid_plan_character",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raid_plan_id": {
+          "name": "raid_plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_name": {
+          "name": "character_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "write_in_class": {
+          "name": "write_in_class",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_group": {
+          "name": "default_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_position": {
+          "name": "default_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_character__raid_plan_id_idx": {
+          "name": "raid_plan_character__raid_plan_id_idx",
+          "columns": [
+            {
+              "expression": "raid_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_plan_character__character_id_idx": {
+          "name": "raid_plan_character__character_id_idx",
+          "columns": [
+            {
+              "expression": "character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_character_raid_plan_id_raid_plan_id_fk": {
+          "name": "raid_plan_character_raid_plan_id_raid_plan_id_fk",
+          "tableFrom": "raid_plan_character",
+          "tableTo": "raid_plan",
+          "columnsFrom": ["raid_plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_plan_character_character_id_character_character_id_fk": {
+          "name": "raid_plan_character_character_id_character_character_id_fk",
+          "tableFrom": "raid_plan_character",
+          "tableTo": "character",
+          "columnsFrom": ["character_id"],
+          "columnsTo": ["character_id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_encounter_aa_slot": {
+      "name": "raid_plan_encounter_aa_slot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "encounter_id": {
+          "name": "encounter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raid_plan_id": {
+          "name": "raid_plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_character_id": {
+          "name": "plan_character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_name": {
+          "name": "slot_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "aa_slot__encounter_id_idx": {
+          "name": "aa_slot__encounter_id_idx",
+          "columns": [
+            {
+              "expression": "encounter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aa_slot__raid_plan_id_idx": {
+          "name": "aa_slot__raid_plan_id_idx",
+          "columns": [
+            {
+              "expression": "raid_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "aa_slot__plan_character_id_idx": {
+          "name": "aa_slot__plan_character_id_idx",
+          "columns": [
+            {
+              "expression": "plan_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_encounter_aa_slot_encounter_id_raid_plan_encounter_id_fk": {
+          "name": "raid_plan_encounter_aa_slot_encounter_id_raid_plan_encounter_id_fk",
+          "tableFrom": "raid_plan_encounter_aa_slot",
+          "tableTo": "raid_plan_encounter",
+          "columnsFrom": ["encounter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_plan_encounter_aa_slot_raid_plan_id_raid_plan_id_fk": {
+          "name": "raid_plan_encounter_aa_slot_raid_plan_id_raid_plan_id_fk",
+          "tableFrom": "raid_plan_encounter_aa_slot",
+          "tableTo": "raid_plan",
+          "columnsFrom": ["raid_plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_plan_encounter_aa_slot_plan_character_id_raid_plan_character_id_fk": {
+          "name": "raid_plan_encounter_aa_slot_plan_character_id_raid_plan_character_id_fk",
+          "tableFrom": "raid_plan_encounter_aa_slot",
+          "tableTo": "raid_plan_character",
+          "columnsFrom": ["plan_character_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_encounter_assignment": {
+      "name": "raid_plan_encounter_assignment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "encounter_id": {
+          "name": "encounter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_character_id": {
+          "name": "plan_character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_encounter_assignment__encounter_id_idx": {
+          "name": "raid_plan_encounter_assignment__encounter_id_idx",
+          "columns": [
+            {
+              "expression": "encounter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_plan_encounter_assignment__plan_character_id_idx": {
+          "name": "raid_plan_encounter_assignment__plan_character_id_idx",
+          "columns": [
+            {
+              "expression": "plan_character_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_encounter_assignment_encounter_id_raid_plan_encounter_id_fk": {
+          "name": "raid_plan_encounter_assignment_encounter_id_raid_plan_encounter_id_fk",
+          "tableFrom": "raid_plan_encounter_assignment",
+          "tableTo": "raid_plan_encounter",
+          "columnsFrom": ["encounter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_plan_encounter_assignment_plan_character_id_raid_plan_character_id_fk": {
+          "name": "raid_plan_encounter_assignment_plan_character_id_raid_plan_character_id_fk",
+          "tableFrom": "raid_plan_encounter_assignment",
+          "tableTo": "raid_plan_character",
+          "columnsFrom": ["plan_character_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_encounter_group": {
+      "name": "raid_plan_encounter_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raid_plan_id": {
+          "name": "raid_plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_encounter_group__raid_plan_id_idx": {
+          "name": "raid_plan_encounter_group__raid_plan_id_idx",
+          "columns": [
+            {
+              "expression": "raid_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_encounter_group_raid_plan_id_raid_plan_id_fk": {
+          "name": "raid_plan_encounter_group_raid_plan_id_raid_plan_id_fk",
+          "tableFrom": "raid_plan_encounter_group",
+          "tableTo": "raid_plan",
+          "columnsFrom": ["raid_plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_encounter": {
+      "name": "raid_plan_encounter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raid_plan_id": {
+          "name": "raid_plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encounter_key": {
+          "name": "encounter_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_name": {
+          "name": "encounter_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "use_default_groups": {
+          "name": "use_default_groups",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "aa_template": {
+          "name": "aa_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_custom_aa": {
+          "name": "use_custom_aa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_encounter__raid_plan_id_idx": {
+          "name": "raid_plan_encounter__raid_plan_id_idx",
+          "columns": [
+            {
+              "expression": "raid_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_plan_encounter__group_id_idx": {
+          "name": "raid_plan_encounter__group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_encounter_raid_plan_id_raid_plan_id_fk": {
+          "name": "raid_plan_encounter_raid_plan_id_raid_plan_id_fk",
+          "tableFrom": "raid_plan_encounter",
+          "tableTo": "raid_plan",
+          "columnsFrom": ["raid_plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_plan_encounter_group_id_raid_plan_encounter_group_id_fk": {
+          "name": "raid_plan_encounter_group_id_raid_plan_encounter_group_id_fk",
+          "tableFrom": "raid_plan_encounter",
+          "tableTo": "raid_plan_encounter_group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_presence": {
+      "name": "raid_plan_presence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raid_plan_id": {
+          "name": "raid_plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_session_id": {
+          "name": "client_session_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewing'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "raid_plan_presence__raid_plan_id_idx": {
+          "name": "raid_plan_presence__raid_plan_id_idx",
+          "columns": [
+            {
+              "expression": "raid_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_plan_presence__user_id_idx": {
+          "name": "raid_plan_presence__user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_plan_presence__last_seen_at_idx": {
+          "name": "raid_plan_presence__last_seen_at_idx",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_plan_presence__plan_session_idx": {
+          "name": "raid_plan_presence__plan_session_idx",
+          "columns": [
+            {
+              "expression": "raid_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_presence_raid_plan_id_raid_plan_id_fk": {
+          "name": "raid_plan_presence_raid_plan_id_raid_plan_id_fk",
+          "tableFrom": "raid_plan_presence",
+          "tableTo": "raid_plan",
+          "columnsFrom": ["raid_plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_plan_presence_user_id_auth_user_id_fk": {
+          "name": "raid_plan_presence_user_id_auth_user_id_fk",
+          "tableFrom": "raid_plan_presence",
+          "tableTo": "auth_user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_template_encounter_group": {
+      "name": "raid_plan_template_encounter_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_template_encounter_group__template_id_idx": {
+          "name": "raid_plan_template_encounter_group__template_id_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_template_encounter_group_template_id_raid_plan_template_id_fk": {
+          "name": "raid_plan_template_encounter_group_template_id_raid_plan_template_id_fk",
+          "tableFrom": "raid_plan_template_encounter_group",
+          "tableTo": "raid_plan_template",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_template_encounter": {
+      "name": "raid_plan_template_encounter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encounter_key": {
+          "name": "encounter_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_name": {
+          "name": "encounter_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "aa_template": {
+          "name": "aa_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_template_encounter__template_id_idx": {
+          "name": "raid_plan_template_encounter__template_id_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_plan_template_encounter__group_id_idx": {
+          "name": "raid_plan_template_encounter__group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_template_encounter_template_id_raid_plan_template_id_fk": {
+          "name": "raid_plan_template_encounter_template_id_raid_plan_template_id_fk",
+          "tableFrom": "raid_plan_template_encounter",
+          "tableTo": "raid_plan_template",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_plan_template_encounter_group_id_raid_plan_template_encounter_group_id_fk": {
+          "name": "raid_plan_template_encounter_group_id_raid_plan_template_encounter_group_id_fk",
+          "tableFrom": "raid_plan_template_encounter",
+          "tableTo": "raid_plan_template_encounter_group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan_template": {
+      "name": "raid_plan_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zone_name": {
+          "name": "zone_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_group_count": {
+          "name": "default_group_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "default_aa_template": {
+          "name": "default_aa_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan_template__zone_id_idx": {
+          "name": "raid_plan_template__zone_id_idx",
+          "columns": [
+            {
+              "expression": "zone_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_template_created_by_auth_user_id_fk": {
+          "name": "raid_plan_template_created_by_auth_user_id_fk",
+          "tableFrom": "raid_plan_template",
+          "tableTo": "auth_user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid_plan": {
+      "name": "raid_plan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "raid_helper_event_id": {
+          "name": "raid_helper_event_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_aa_template": {
+          "name": "default_aa_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_default_aa": {
+          "name": "use_default_aa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid_plan__raid_helper_event_id_idx": {
+          "name": "raid_plan__raid_helper_event_id_idx",
+          "columns": [
+            {
+              "expression": "raid_helper_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raid_plan__event_id_idx": {
+          "name": "raid_plan__event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_plan_event_id_raid_raid_id_fk": {
+          "name": "raid_plan_event_id_raid_raid_id_fk",
+          "tableFrom": "raid_plan",
+          "tableTo": "raid",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["raid_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "raid_plan_created_by_auth_user_id_fk": {
+          "name": "raid_plan_created_by_auth_user_id_fk",
+          "tableFrom": "raid_plan",
+          "tableTo": "auth_user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "raid_plan_updated_by_auth_user_id_fk": {
+          "name": "raid_plan_updated_by_auth_user_id_fk",
+          "tableFrom": "raid_plan",
+          "tableTo": "auth_user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raid": {
+      "name": "raid",
+      "schema": "",
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_weight": {
+          "name": "attendance_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "zone": {
+          "name": "zone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "raid__raid_id_idx": {
+          "name": "raid__raid_id_idx",
+          "columns": [
+            {
+              "expression": "raid_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raid_created_by_auth_user_id_fk": {
+          "name": "raid_created_by_auth_user_id_fk",
+          "tableFrom": "raid",
+          "tableTo": "auth_user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "raid_updated_by_auth_user_id_fk": {
+          "name": "raid_updated_by_auth_user_id_fk",
+          "tableFrom": "raid",
+          "tableTo": "auth_user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipes": {
+      "name": "recipes",
+      "schema": "",
+      "columns": {
+        "recipe_spell_id": {
+          "name": "recipe_spell_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profession": {
+          "name": "profession",
+          "type": "profession",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe": {
+          "name": "recipe",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_common": {
+          "name": "is_common",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recipes_created_by_auth_user_id_fk": {
+          "name": "recipes_created_by_auth_user_id_fk",
+          "tableFrom": "recipes",
+          "tableTo": "auth_user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "recipes_updated_by_auth_user_id_fk": {
+          "name": "recipes_updated_by_auth_user_id_fk",
+          "tableFrom": "recipes",
+          "tableTo": "auth_user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_auth_user_id_fk": {
+          "name": "auth_session_user_id_auth_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "auth_user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_user": {
+      "name": "auth_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_raid_manager": {
+          "name": "is_raid_manager",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_token": {
+          "name": "api_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_token_encrypted": {
+          "name": "api_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "templar_enabled": {
+          "name": "templar_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user__id_idx": {
+          "name": "user__id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user__api_token_idx": {
+          "name": "user__api_token_idx",
+          "columns": [
+            {
+              "expression": "api_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification_token": {
+      "name": "auth_verification_token",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "auth_verification_token_identifier_token_pk": {
+          "name": "auth_verification_token_identifier_token_pk",
+          "columns": ["identifier", "token"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.created_via": {
+      "name": "created_via",
+      "schema": "public",
+      "values": ["ui", "wcl_raid_log_import"]
+    },
+    "public.profession": {
+      "name": "profession",
+      "schema": "public",
+      "values": [
+        "Alchemy",
+        "Blacksmithing",
+        "Enchanting",
+        "Engineering",
+        "Tailoring",
+        "Leatherworking",
+        "Cooking"
+      ]
+    },
+    "public.updated_via": {
+      "name": "updated_via",
+      "schema": "public",
+      "values": ["ui", "wcl_raid_log_import"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "views.all_raids_current_lockout": {
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_weight": {
+          "name": "attendance_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "zone": {
+          "name": "zone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "name": "all_raids_current_lockout",
+      "schema": "views",
+      "isExisting": true,
+      "materialized": false
+    },
+    "views.primary_raid_attendance_l6lockoutwk": {
+      "columns": {
+        "character_id": {
+          "name": "character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weighted_attendance": {
+          "name": "weighted_attendance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weighted_raid_total": {
+          "name": "weighted_raid_total",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weighted_attendance_pct": {
+          "name": "weighted_attendance_pct",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "name": "primary_raid_attendance_l6lockoutwk",
+      "schema": "views",
+      "isExisting": true,
+      "materialized": false
+    },
+    "views.primary_raid_attendee_and_bench_map": {
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_character_id": {
+          "name": "primary_character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_character_ids": {
+          "name": "all_character_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendee_or_bench": {
+          "name": "attendee_or_bench",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_characters": {
+          "name": "all_characters",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raid_log_ids": {
+          "name": "raid_log_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "name": "primary_raid_attendee_and_bench_map",
+      "schema": "views",
+      "isExisting": true,
+      "materialized": false
+    },
+    "views.primary_raid_attendee_map": {
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_character_id": {
+          "name": "primary_character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attending_character_ids": {
+          "name": "attending_character_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "name": "primary_raid_attendee_map",
+      "schema": "views",
+      "isExisting": true,
+      "materialized": false
+    },
+    "views.primary_raid_bench_map": {
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_character_id": {
+          "name": "primary_character_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bench_character_ids": {
+          "name": "bench_character_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "name": "primary_raid_bench_map",
+      "schema": "views",
+      "isExisting": true,
+      "materialized": false
+    },
+    "views.report_dates": {
+      "columns": {
+        "report_period_start": {
+          "name": "report_period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_period_end": {
+          "name": "report_period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "name": "report_dates",
+      "schema": "views",
+      "isExisting": true,
+      "materialized": false
+    },
+    "views.tracked_raids_current_lockout": {
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_weight": {
+          "name": "attendance_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "zone": {
+          "name": "zone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "name": "tracked_raids_current_lockout",
+      "schema": "views",
+      "isExisting": true,
+      "materialized": false
+    },
+    "views.tracked_raids_l6lockoutwk": {
+      "columns": {
+        "raid_id": {
+          "name": "raid_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendance_weight": {
+          "name": "attendance_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "zone": {
+          "name": "zone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lockout_week": {
+          "name": "lockout_week",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "name": "tracked_raids_l6lockoutwk",
+      "schema": "views",
+      "isExisting": true,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1777343397698,
       "tag": "0022_fix-lockout-views-et-timezone",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1777717392281,
+      "tag": "0023_tough_namorita",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/discord/proxy/[discordId]/route.ts
+++ b/src/app/api/discord/proxy/[discordId]/route.ts
@@ -107,7 +107,11 @@ export async function POST(
 
     const targetUser = userResult[0]!;
 
-    // 4. Check opt-in
+    // 4. Check opt-in.
+    // Note: only raid managers/admins can toggle templarEnabled (enforced at the
+    // PATCH /me/templar endpoint and the setTemplarEnabled tRPC mutation). If a
+    // user later loses their manager role, their proxied calls will still be
+    // attempted but will fail at the endpoint level via raidManagerProcedure.
     if (!targetUser.templarEnabled) {
       return NextResponse.json(
         { error: "Templar access not enabled" },

--- a/src/app/api/discord/proxy/[discordId]/route.ts
+++ b/src/app/api/discord/proxy/[discordId]/route.ts
@@ -20,11 +20,23 @@ const ProxySchema = z.object({
     .string()
     .min(1)
     .startsWith("/")
-    .refine(
-      (p) =>
-        !p.toLowerCase().startsWith("/admin/proxy") &&
-        !p.toLowerCase().startsWith("/discord/proxy"),
-      { message: "Recursive proxy calls are not allowed" },
+    .transform((p) => {
+      try {
+        const normalized = new URL(`http://x/api/v1${p}`).pathname;
+        return normalized.slice("/api/v1".length) || "/";
+      } catch {
+        return p;
+      }
+    })
+    .pipe(
+      z
+        .string()
+        .startsWith("/")
+        .refine(
+          (p) =>
+            !p.startsWith("/discord/proxy") && !p.startsWith("/admin/proxy"),
+          { message: "Recursive proxy calls are not allowed" },
+        ),
     ),
   body: z.unknown().optional(),
 });
@@ -37,6 +49,11 @@ export async function POST(
     // 1. Verify bot service key (same pattern as all /api/discord/* endpoints)
     const authHeader = request.headers.get("authorization");
     if (authHeader !== `Bearer ${env.TEMPLE_WEB_API_TOKEN}`) {
+      console.warn("Unauthorized discord proxy attempt", {
+        ip: request.headers.get("x-forwarded-for"),
+        userAgent: request.headers.get("user-agent"),
+        timestamp: new Date().toISOString(),
+      });
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -59,6 +76,13 @@ export async function POST(
 
     const { method, path, body: proxyBody } = parsed.data;
     const { discordId } = await params;
+
+    if (!/^\d{17,19}$/.test(discordId)) {
+      return NextResponse.json(
+        { error: "Invalid Discord user ID" },
+        { status: 400 },
+      );
+    }
 
     // 3. Look up user by Discord ID via accounts table
     const userResult = await db
@@ -132,7 +156,10 @@ export async function POST(
     const upstreamText = await upstreamResponse.text();
     return new NextResponse(upstreamText, {
       status: upstreamResponse.status,
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type":
+          upstreamResponse.headers.get("content-type") ?? "application/json",
+      },
     });
   } catch (error) {
     console.error("discord proxy error:", error);

--- a/src/app/api/discord/proxy/[discordId]/route.ts
+++ b/src/app/api/discord/proxy/[discordId]/route.ts
@@ -1,0 +1,144 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { decryptToken } from "~/server/api/token-crypto";
+import { db } from "~/server/db";
+import { users, accounts } from "~/server/db/schema";
+import { and, eq } from "drizzle-orm";
+import { getBaseUrl } from "~/lib/get-base-url";
+import { env } from "~/env.js";
+
+const ALLOWED_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]);
+
+const ProxySchema = z.object({
+  method: z
+    .string()
+    .toUpperCase()
+    .refine((m) => ALLOWED_METHODS.has(m), {
+      message: "method must be GET, POST, PUT, PATCH, or DELETE",
+    }),
+  path: z
+    .string()
+    .min(1)
+    .startsWith("/")
+    .refine(
+      (p) =>
+        !p.toLowerCase().startsWith("/admin/proxy") &&
+        !p.toLowerCase().startsWith("/discord/proxy"),
+      { message: "Recursive proxy calls are not allowed" },
+    ),
+  body: z.unknown().optional(),
+});
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ discordId: string }> },
+) {
+  try {
+    // 1. Verify bot service key (same pattern as all /api/discord/* endpoints)
+    const authHeader = request.headers.get("authorization");
+    if (authHeader !== `Bearer ${env.TEMPLE_WEB_API_TOKEN}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // 2. Parse and validate request body
+    let body: unknown;
+    try {
+      const text = await request.text();
+      body = text ? JSON.parse(text) : {};
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const parsed = ProxySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Validation error", issues: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+
+    const { method, path, body: proxyBody } = parsed.data;
+    const { discordId } = await params;
+
+    // 3. Look up user by Discord ID via accounts table
+    const userResult = await db
+      .select({
+        id: users.id,
+        templarEnabled: users.templarEnabled,
+        apiTokenEncrypted: users.apiTokenEncrypted,
+      })
+      .from(users)
+      .innerJoin(accounts, eq(accounts.userId, users.id))
+      .where(
+        and(
+          eq(accounts.provider, "discord"),
+          eq(accounts.providerAccountId, discordId),
+        ),
+      )
+      .limit(1);
+
+    if (userResult.length === 0) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    const targetUser = userResult[0]!;
+
+    // 4. Check opt-in
+    if (!targetUser.templarEnabled) {
+      return NextResponse.json(
+        { error: "Templar access not enabled" },
+        { status: 403 },
+      );
+    }
+
+    // 5. Decrypt token
+    if (!targetUser.apiTokenEncrypted) {
+      return NextResponse.json(
+        {
+          error:
+            "User has no encrypted token. They must regenerate their API token to enable Templar proxy.",
+        },
+        { status: 409 },
+      );
+    }
+
+    let plainToken: string;
+    try {
+      plainToken = decryptToken(targetUser.apiTokenEncrypted);
+    } catch {
+      return NextResponse.json(
+        { error: "Failed to decrypt user token" },
+        { status: 500 },
+      );
+    }
+
+    // 6. Forward the request to /api/v1
+    const baseUrl = getBaseUrl(request);
+    const targetUrl = `${baseUrl}/api/v1${path}`;
+
+    const proxyHeaders: HeadersInit = {
+      Authorization: `Bearer ${plainToken}`,
+      "Content-Type": "application/json",
+    };
+
+    const hasBody = proxyBody !== undefined && method !== "GET";
+    const upstreamResponse = await fetch(targetUrl, {
+      method,
+      headers: proxyHeaders,
+      body: hasBody ? JSON.stringify(proxyBody) : undefined,
+    });
+
+    // 7. Return the upstream response exactly as-is
+    const upstreamText = await upstreamResponse.text();
+    return new NextResponse(upstreamText, {
+      status: upstreamResponse.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error("discord proxy error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/v1/me/route.ts
+++ b/src/app/api/v1/me/route.ts
@@ -30,6 +30,7 @@ export async function GET(request: Request) {
       image: user.image,
       isRaidManager: user.isRaidManager,
       isAdmin: user.isAdmin,
+      templarEnabled: user.templarEnabled ?? false,
       character: character ?? null,
     });
   } catch (error) {

--- a/src/app/api/v1/me/templar/route.ts
+++ b/src/app/api/v1/me/templar/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { validateApiToken } from "~/server/api/v1-auth";
+import { db } from "~/server/db";
+import { users } from "~/server/db/schema";
+import { eq } from "drizzle-orm";
+
+const PatchSchema = z.object({
+  enabled: z.boolean(),
+});
+
+export async function PATCH(request: Request) {
+  try {
+    const authResult = await validateApiToken(request);
+    if ("error" in authResult) return authResult.error;
+    const { user } = authResult;
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    const parsed = PatchSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Validation error", issues: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+
+    await db
+      .update(users)
+      .set({ templarEnabled: parsed.data.enabled })
+      .where(eq(users.id, user.id));
+
+    const updated = await db
+      .select({
+        id: users.id,
+        name: users.name,
+        image: users.image,
+        isRaidManager: users.isRaidManager,
+        isAdmin: users.isAdmin,
+        templarEnabled: users.templarEnabled,
+      })
+      .from(users)
+      .where(eq(users.id, user.id))
+      .limit(1);
+
+    const u = updated[0]!;
+    return NextResponse.json({
+      id: u.id,
+      name: u.name,
+      image: u.image,
+      isRaidManager: u.isRaidManager,
+      isAdmin: u.isAdmin,
+      templarEnabled: u.templarEnabled ?? false,
+    });
+  } catch (error) {
+    console.error("v1 API error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/v1/me/templar/route.ts
+++ b/src/app/api/v1/me/templar/route.ts
@@ -15,6 +15,10 @@ export async function PATCH(request: Request) {
     if ("error" in authResult) return authResult.error;
     const { user } = authResult;
 
+    if (!user.isRaidManager && !user.isAdmin) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
     let body: unknown;
     try {
       body = await request.json();
@@ -30,25 +34,23 @@ export async function PATCH(request: Request) {
       );
     }
 
-    await db
+    const [u] = await db
       .update(users)
       .set({ templarEnabled: parsed.data.enabled })
-      .where(eq(users.id, user.id));
-
-    const updated = await db
-      .select({
+      .where(eq(users.id, user.id))
+      .returning({
         id: users.id,
         name: users.name,
         image: users.image,
         isRaidManager: users.isRaidManager,
         isAdmin: users.isAdmin,
         templarEnabled: users.templarEnabled,
-      })
-      .from(users)
-      .where(eq(users.id, user.id))
-      .limit(1);
+      });
 
-    const u = updated[0]!;
+    if (!u) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
     return NextResponse.json({
       id: u.id,
       name: u.name,

--- a/src/components/profile/api-access-card.tsx
+++ b/src/components/profile/api-access-card.tsx
@@ -253,12 +253,11 @@ export function ApiAccessCard() {
                 }
               />
               <Label htmlFor="templar-enabled" className="text-sm">
-                Enable Templar (Discord ChatBot) to take actions on my behalf
+                Allow Templar (Discord bot) to act when you ask it to
               </Label>
             </div>
             <p className="pl-10 text-xs text-muted-foreground">
-              When disabled, the bot will refuse requests involving your
-              account.
+              When disabled, Templar will ignore your requests.
             </p>
           </div>
         )}

--- a/src/components/profile/api-access-card.tsx
+++ b/src/components/profile/api-access-card.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import { api } from "~/trpc/react";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Switch } from "~/components/ui/switch";
+import { Label } from "~/components/ui/label";
 import { Copy, KeyRound, Trash2 } from "lucide-react";
 import { useToast } from "~/hooks/use-toast";
 
@@ -53,6 +55,24 @@ export function ApiAccessCard() {
     },
   });
 
+  const setTemplarEnabled = api.profile.setTemplarEnabled.useMutation({
+    onSuccess: (data) => {
+      void utils.profile.getMyProfile.invalidate();
+      toast({
+        title: data.templarEnabled
+          ? "Templar access enabled"
+          : "Templar access disabled",
+      });
+    },
+    onError: (err) => {
+      toast({
+        title: "Failed to update Templar access",
+        description: err.message,
+        variant: "destructive",
+      });
+    },
+  });
+
   const handleCopy = async () => {
     if (!newToken) return;
     try {
@@ -71,15 +91,16 @@ export function ApiAccessCard() {
     setNewToken(null);
   };
 
-  // Don't render until we know the user's role
   if (isLoading || !profile) return null;
 
-  const { isRaidManager, isAdmin, hasApiToken } = profile;
+  const { isRaidManager, isAdmin, hasApiToken, templarEnabled } = profile;
 
-  // Only show for raid managers and admins
   if (!isRaidManager && !isAdmin) return null;
 
-  const isPending = generateToken.isPending || revokeToken.isPending;
+  const isPending =
+    generateToken.isPending ||
+    revokeToken.isPending ||
+    setTemplarEnabled.isPending;
 
   return (
     <Card>
@@ -109,7 +130,6 @@ export function ApiAccessCard() {
         {/* Actions */}
         <div className="flex flex-wrap items-center gap-2">
           {!hasApiToken && !newToken ? (
-            // No token — show Generate
             <Button
               size="sm"
               onClick={() => generateToken.mutate()}
@@ -119,7 +139,6 @@ export function ApiAccessCard() {
             </Button>
           ) : (
             <>
-              {/* Regenerate */}
               {confirmAction === "regenerate" ? (
                 <div className="flex items-center gap-2">
                   <span className="text-sm text-muted-foreground">
@@ -218,6 +237,29 @@ export function ApiAccessCard() {
             >
               Dismiss
             </Button>
+          </div>
+        )}
+
+        {/* Templar toggle — only shown when a token exists */}
+        {(hasApiToken || newToken) && (
+          <div className="flex flex-col gap-1 border-t pt-4">
+            <div className="flex items-center gap-3">
+              <Switch
+                id="templar-enabled"
+                checked={templarEnabled ?? false}
+                disabled={isPending}
+                onCheckedChange={(checked) =>
+                  setTemplarEnabled.mutate({ enabled: checked })
+                }
+              />
+              <Label htmlFor="templar-enabled" className="text-sm">
+                Enable Templar (Discord ChatBot) to take actions on my behalf
+              </Label>
+            </div>
+            <p className="pl-10 text-xs text-muted-foreground">
+              When disabled, the bot will refuse requests involving your
+              account.
+            </p>
           </div>
         )}
       </CardContent>

--- a/src/components/profile/api-access-card.tsx
+++ b/src/components/profile/api-access-card.tsx
@@ -257,7 +257,8 @@ export function ApiAccessCard() {
               </Label>
             </div>
             <p className="pl-10 text-xs text-muted-foreground">
-              When disabled, Templar will ignore your requests.
+              Templar is currently available to Raid Leads only. When disabled,
+              Templar will ignore your requests.
             </p>
           </div>
         )}

--- a/src/components/profile/api-access-card.tsx
+++ b/src/components/profile/api-access-card.tsx
@@ -257,8 +257,8 @@ export function ApiAccessCard() {
               </Label>
             </div>
             <p className="pl-10 text-xs text-muted-foreground">
-              Templar is currently available to Raid Leads only. When disabled,
-              Templar will ignore your requests.
+              Templar is available to Raid Managers only. When disabled, Templar
+              will ignore your requests.
             </p>
           </div>
         )}

--- a/src/env.js
+++ b/src/env.js
@@ -34,6 +34,7 @@ export const env = createEnv({
     DISCORD_SERVER_ID: z.string(),
     RAID_HELPER_API_KEY: z.string(),
     TEMPLE_WEB_API_TOKEN: z.string(),
+    API_TOKEN_ENCRYPTION_KEY: z.string().min(1),
 
     NODE_ENV: z
       .enum(["development", "test", "production"])
@@ -81,6 +82,7 @@ export const env = createEnv({
     DISCORD_SERVER_ID: process.env.DISCORD_SERVER_ID,
     RAID_HELPER_API_KEY: process.env.RAID_HELPER_API_KEY,
     TEMPLE_WEB_API_TOKEN: process.env.TEMPLE_WEB_API_TOKEN,
+    API_TOKEN_ENCRYPTION_KEY: process.env.API_TOKEN_ENCRYPTION_KEY,
 
     NEXT_PUBLIC_POSTHOG_ENABLED: process.env.NEXT_PUBLIC_POSTHOG_ENABLED,
     NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,

--- a/src/lib/openapi-registry.ts
+++ b/src/lib/openapi-registry.ts
@@ -88,6 +88,7 @@ export const MeSchema = registry.register(
       .openapi({ example: "https://cdn.discordapp.com/avatars/..." }),
     isRaidManager: z.boolean().nullable().openapi({ example: false }),
     isAdmin: z.boolean().nullable().openapi({ example: false }),
+    templarEnabled: z.boolean().openapi({ example: false }),
     character: z
       .object({
         characterId: z.number().openapi({ example: 12345 }),
@@ -222,12 +223,9 @@ const EncounterSchema = z.object({
   sortOrder: z.number().nullable().openapi({ example: 0 }),
   groupId: z.string().uuid().nullable().openapi({ example: null }),
   useDefaultGroups: z.boolean().nullable().openapi({ example: true }),
-  aaTemplate: z
-    .string()
-    .nullable()
-    .openapi({
-      example: "{skull} {assign:MainTank} :: {assign:MainTankHeals}",
-    }),
+  aaTemplate: z.string().nullable().openapi({
+    example: "{skull} {assign:MainTank} :: {assign:MainTankHeals}",
+  }),
   useCustomAA: z.boolean().nullable().openapi({ example: false }),
   availableSlots: z
     .array(z.string())
@@ -416,6 +414,35 @@ registry.registerPath({
       },
     },
     401: { description: "Invalid or missing API token" },
+  },
+});
+
+registry.registerPath({
+  method: "patch",
+  path: "/api/v1/me/templar",
+  operationId: "patchMeTemplar",
+  tags: ["User"],
+  summary: "Toggle Templar bot access",
+  description:
+    "Enable or disable the Templar Discord bot from acting on your behalf via the admin proxy.",
+  security: [{ BearerToken: [] }],
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({ enabled: z.boolean().openapi({ example: true }) }),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Updated Me object",
+      content: { "application/json": { schema: MeSchema } },
+    },
+    400: { description: "Validation error" },
+    401: { description: "Unauthorized" },
+    403: { description: "Forbidden — requires raid manager or admin role" },
   },
 });
 
@@ -664,14 +691,10 @@ registry.registerPath({
       content: {
         "application/json": {
           schema: z.object({
-            defaultAATemplate: z
-              .string()
-              .nullable()
-              .optional()
-              .openapi({
-                example:
-                  "{skull} {assign:MainTank} :: {assign:MainTankHeals}\n{assign:TranqShot1} {assign:TranqShot2} Tranq",
-              }),
+            defaultAATemplate: z.string().nullable().optional().openapi({
+              example:
+                "{skull} {assign:MainTank} :: {assign:MainTankHeals}\n{assign:TranqShot1} {assign:TranqShot2} Tranq",
+            }),
             useDefaultAA: z.boolean().optional().openapi({ example: true }),
           }),
         },
@@ -688,12 +711,9 @@ registry.registerPath({
               .string()
               .uuid()
               .openapi({ example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" }),
-            defaultAATemplate: z
-              .string()
-              .nullable()
-              .openapi({
-                example: "{skull} {assign:MainTank} :: {assign:MainTankHeals}",
-              }),
+            defaultAATemplate: z.string().nullable().openapi({
+              example: "{skull} {assign:MainTank} :: {assign:MainTankHeals}",
+            }),
             useDefaultAA: z.boolean().nullable().openapi({ example: true }),
             availableSlots: z
               .array(z.string())
@@ -1070,12 +1090,9 @@ const ZoneTemplateEncounterSchema = z.object({
   encounterName: z.string().openapi({ example: "Patchwerk" }),
   sortOrder: z.number().int().openapi({ example: 0 }),
   groupId: z.string().uuid().nullable().openapi({ example: null }),
-  aaTemplate: z
-    .string()
-    .nullable()
-    .openapi({
-      example: "{skull} {assign:MainTank} :: {assign:MainTankHeals}",
-    }),
+  aaTemplate: z.string().nullable().openapi({
+    example: "{skull} {assign:MainTank} :: {assign:MainTankHeals}",
+  }),
 });
 
 const ZoneTemplateGroupSchema = z.object({
@@ -1093,12 +1110,9 @@ const ZoneTemplateDetailSchema = z.object({
     .uuid()
     .openapi({ example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" }),
   isActive: z.boolean().openapi({ example: true }),
-  defaultAATemplate: z
-    .string()
-    .nullable()
-    .openapi({
-      example: "{skull} {assign:MainTank} :: {assign:MainTankHeals}",
-    }),
+  defaultAATemplate: z.string().nullable().openapi({
+    example: "{skull} {assign:MainTank} :: {assign:MainTankHeals}",
+  }),
   availableSlots: z
     .array(z.string())
     .openapi({ example: ["MainTank", "MainTankHeals"] }),
@@ -1219,12 +1233,9 @@ registry.registerPath({
               .uuid()
               .openapi({ example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" }),
             isActive: z.boolean().openapi({ example: true }),
-            defaultAATemplate: z
-              .string()
-              .nullable()
-              .openapi({
-                example: "{skull} {assign:MainTank} :: {assign:MainTankHeals}",
-              }),
+            defaultAATemplate: z.string().nullable().openapi({
+              example: "{skull} {assign:MainTank} :: {assign:MainTankHeals}",
+            }),
             availableSlots: z
               .array(z.string())
               .openapi({ example: ["MainTank", "MainTankHeals"] }),
@@ -1266,12 +1277,9 @@ registry.registerPath({
               .nullable()
               .optional()
               .openapi({ example: null }),
-            aaTemplate: z
-              .string()
-              .optional()
-              .openapi({
-                example: "{skull} {assign:MainTank} :: {assign:MainTankHeals}",
-              }),
+            aaTemplate: z.string().optional().openapi({
+              example: "{skull} {assign:MainTank} :: {assign:MainTankHeals}",
+            }),
           }),
         },
       },
@@ -1313,14 +1321,9 @@ registry.registerPath({
               .max(256)
               .optional()
               .openapi({ example: "Patchwerk" }),
-            aaTemplate: z
-              .string()
-              .max(10000)
-              .nullable()
-              .optional()
-              .openapi({
-                example: "{skull} {assign:MainTank} :: {assign:MainTankHeals}",
-              }),
+            aaTemplate: z.string().max(10000).nullable().optional().openapi({
+              example: "{skull} {assign:MainTank} :: {assign:MainTankHeals}",
+            }),
             sortOrder: z.number().int().optional().openapi({ example: 3 }),
             groupId: z
               .string()

--- a/src/server/api/routers/profile.ts
+++ b/src/server/api/routers/profile.ts
@@ -17,6 +17,7 @@ export const profile = createTRPCRouter({
         isRaidManager: true,
         isAdmin: true,
         apiToken: true,
+        templarEnabled: true,
       },
       with: {
         character: {
@@ -58,6 +59,7 @@ export const profile = createTRPCRouter({
         isRaidManager: false,
         isAdmin: false,
         hasApiToken: false,
+        templarEnabled: false,
         character: { name: "", characterId: -1, class: "" },
         userCharacterIds: [],
       };
@@ -87,6 +89,7 @@ export const profile = createTRPCRouter({
       ...user,
       apiToken: undefined,
       hasApiToken: user.apiToken !== null,
+      templarEnabled: user.templarEnabled ?? false,
       userCharacterIds: Array.from(userCharacterIds),
     };
   }),

--- a/src/server/api/routers/profile.ts
+++ b/src/server/api/routers/profile.ts
@@ -164,4 +164,21 @@ export const profile = createTRPCRouter({
 
     return { success: true };
   }),
+
+  setTemplarEnabled: protectedProcedure
+    .input(z.object({ enabled: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      const { isRaidManager, isAdmin } = ctx.session.user;
+      if (!isRaidManager && !isAdmin) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Only raid managers and admins can manage Templar access.",
+        });
+      }
+      await ctx.db
+        .update(users)
+        .set({ templarEnabled: input.enabled })
+        .where(eq(users.id, ctx.session.user.id));
+      return { templarEnabled: input.enabled };
+    }),
 });

--- a/src/server/api/routers/profile.ts
+++ b/src/server/api/routers/profile.ts
@@ -4,6 +4,7 @@ import { TRPCError } from "@trpc/server";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { users } from "~/server/db/schema";
 import { eq } from "drizzle-orm";
+import { encryptToken } from "~/server/api/token-crypto";
 
 export const profile = createTRPCRouter({
   getMyProfile: protectedProcedure.query(async ({ ctx }) => {
@@ -134,10 +135,11 @@ export const profile = createTRPCRouter({
 
     const token = `tera_${crypto.randomBytes(16).toString("hex")}`;
     const tokenHash = crypto.createHash("sha256").update(token).digest("hex");
+    const tokenEncrypted = encryptToken(token);
 
     await ctx.db
       .update(users)
-      .set({ apiToken: tokenHash })
+      .set({ apiToken: tokenHash, apiTokenEncrypted: tokenEncrypted })
       .where(eq(users.id, ctx.session.user.id));
 
     return { token, replaced };
@@ -154,7 +156,7 @@ export const profile = createTRPCRouter({
 
     await ctx.db
       .update(users)
-      .set({ apiToken: null })
+      .set({ apiToken: null, apiTokenEncrypted: null })
       .where(eq(users.id, ctx.session.user.id));
 
     return { success: true };

--- a/src/server/api/token-crypto.ts
+++ b/src/server/api/token-crypto.ts
@@ -1,0 +1,44 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "crypto";
+import { env } from "~/env.js";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+const TAG_LENGTH = 16;
+
+function getKey(): Buffer {
+  return Buffer.from(env.API_TOKEN_ENCRYPTION_KEY, "base64url");
+}
+
+/**
+ * Encrypts a plaintext token.
+ * Returns a base64url string: iv(12) + ciphertext + authTag(16)
+ */
+export function encryptToken(plaintext: string): string {
+  const key = getKey();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+  return Buffer.concat([iv, ciphertext, authTag]).toString("base64url");
+}
+
+/**
+ * Decrypts a base64url string produced by encryptToken.
+ * Throws if tampered or key mismatch.
+ */
+export function decryptToken(encrypted: string): string {
+  const key = getKey();
+  const buf = Buffer.from(encrypted, "base64url");
+  const iv = buf.subarray(0, IV_LENGTH);
+  const authTag = buf.subarray(buf.length - TAG_LENGTH);
+  const ciphertext = buf.subarray(IV_LENGTH, buf.length - TAG_LENGTH);
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]).toString("utf8");
+}

--- a/src/server/api/v1-auth.ts
+++ b/src/server/api/v1-auth.ts
@@ -13,6 +13,7 @@ type ValidateApiTokenResult =
         isRaidManager: boolean | null;
         isAdmin: boolean | null;
         characterId: number | null;
+        templarEnabled: boolean | null;
       };
     }
   | { error: NextResponse };
@@ -73,6 +74,7 @@ export async function validateApiToken(
       isRaidManager: users.isRaidManager,
       isAdmin: users.isAdmin,
       characterId: users.characterId,
+      templarEnabled: users.templarEnabled,
     })
     .from(users)
     .where(eq(users.apiToken, tokenHash))

--- a/src/server/db/models/auth-schema.ts
+++ b/src/server/db/models/auth-schema.ts
@@ -36,6 +36,8 @@ export const users = tableCreator(
     characterId: integer("character_id"),
     // Nullable: users without a token have NULL. Unique index allows multiple NULLs (PG B-tree behavior).
     apiToken: text("api_token"),
+    apiTokenEncrypted: text("api_token_encrypted"),
+    templarEnabled: boolean("templar_enabled").notNull().default(false),
   },
   (user) => ({
     idIdx: uniqueIndex("user__id_idx").on(user.id),


### PR DESCRIPTION
## Summary

- Adds opt-in toggle for Raid Managers to allow the Templar Discord bot to act on their behalf when asked
- New _POST /api/discord/proxy/{discordId}_ endpoint lets the bot forward v1 API calls using the user's own token (server-side only — token never leaves the wire)
- User tokens are stored as AES-256-GCM encrypted copies alongside the existing SHA-256 hash; encrypted copy is used exclusively by the proxy
- Proxy enforces opt-in check (_templarEnabled_), falls back gracefully with a 409 if user hasn't regenerated their token since this change

## Test Plan
- [ ] Raid Manager can toggle Templar access on/off from profile page
- [ ] Toggle is visible only when a token exists and user is a Raid Manager/Admin
- [ ] _GET /api/v1/me_ returns _templarEnabled_ field
- [ ] _PATCH /api/v1/me/templar_ updates the flag (Raid Manager/Admin only — 403 otherwise)
- [ ] Proxy returns 401 on bad admin key, 403 on templar disabled, 409 on missing encrypted token, 200 passthrough on success
- [ ] Proxy correctly forwards upstream status codes and bodies unchanged

> **Note:** Templar is available to Raid Managers only at this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)