### PR TITLE
Optimize Next.js build config and drop @heroicons dependency

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,8 +7,11 @@ import "./src/env.js";
 /** @type {import("next").NextConfig} */
 const config = {
   eslint: {
-    // Ensure linting runs during next build locally, matching Vercel's behavior
-    ignoreDuringBuilds: false,
+    // ESLint removed in favour of oxlint (runs via lefthook, not next build)
+    ignoreDuringBuilds: true,
+  },
+  experimental: {
+    optimizePackageImports: ["lucide-react", "date-fns", "date-fns-tz"],
   },
   async redirects() {
     return [

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@heroicons/react": "^2.2.0",
     "@radix-ui/react-accordion": "^1.2.3",
     "@radix-ui/react-alert-dialog": "^1.1.4",
     "@radix-ui/react-aspect-ratio": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@18.3.1)
-      '@heroicons/react':
-        specifier: ^2.2.0
-        version: 2.2.0(react@18.3.1)
       '@radix-ui/react-accordion':
         specifier: ^1.2.3
         version: 1.2.12(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -609,11 +606,6 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
-
-  '@heroicons/react@2.2.0':
-    resolution: {integrity: sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==}
-    peerDependencies:
-      react: '>= 16 || ^19.0.0-rc'
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -3593,10 +3585,6 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   '@floating-ui/utils@0.2.10': {}
-
-  '@heroicons/react@2.2.0(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
 
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:

--- a/src/components/nav/app-sidebar.tsx
+++ b/src/components/nav/app-sidebar.tsx
@@ -10,7 +10,6 @@ import {
   SidebarMenuItem,
   SidebarSeparator,
 } from "@/components/ui/sidebar";
-import { ChartBarSquareIcon, MapIcon, UserGroupIcon } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { auth } from "~/server/auth";
 import { AppSidebarLogin } from "~/components/nav/app-sidebar-login";
@@ -25,6 +24,8 @@ import {
   ClipboardList,
   LayoutGrid,
   DraftingCompass,
+  LayoutDashboard,
+  Swords,
 } from "lucide-react";
 import { SidebarSearchBox } from "~/components/nav/sidebar-search-box";
 
@@ -35,10 +36,10 @@ const mutedTooltip = (label: string) =>
   }) as const;
 
 const coreItems = [
-  { title: "Dashboard", url: "/", icon: ChartBarSquareIcon },
-  { title: "Raids", url: "/raids", icon: MapIcon },
+  { title: "Dashboard", url: "/", icon: LayoutDashboard },
+  { title: "Raids", url: "/raids", icon: Swords },
   { title: "Raid Plans", url: "/raid-plans", icon: DraftingCompass },
-  { title: "Raiding characters", url: "/characters", icon: UserGroupIcon },
+  { title: "Raiding characters", url: "/characters", icon: Users },
   { title: "Rare recipes & crafters", url: "/rare-recipes", icon: Wand },
 ];
 


### PR DESCRIPTION
Three small changes that reduce build overhead and clean up the dependency tree.

### Technical details

- Added _optimizePackageImports_ for _lucide-react_, _date-fns_, and _date-fns-tz_ — prevents Next.js from bundling entire icon/date libraries during compilation
- Set _eslint.ignoreDuringBuilds: true_ — ESLint was removed in #231; this reflects that and prevents accidental re-enabling
- Replaced 3 _@heroicons/react_ icons in _app-sidebar.tsx_ with _lucide-react_ equivalents (_LayoutDashboard_, _Swords_, _Users_) and removed the package entirely