### PR TITLE
Add planUrl and compact mode to raid plan GET endpoint

### DIFF
--- a/src/app/api/v1/raid-plans/[id]/route.ts
+++ b/src/app/api/v1/raid-plans/[id]/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { logger } from "~/lib/logger";
 import { validateApiToken } from "~/server/api/v1-auth";
 import { getSlotNames } from "~/lib/aa-template";
+import { getBaseUrl } from "~/lib/get-base-url";
 import { db } from "~/server/db";
 import {
   raidPlans,
@@ -38,6 +39,9 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       return NextResponse.json({ error: "Invalid plan ID" }, { status: 400 });
     }
 
+    const url = new URL(request.url);
+    const compact = url.searchParams.get("compact") === "true";
+
     const plan = await db
       .select({
         id: raidPlans.id,
@@ -58,50 +62,56 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       return NextResponse.json({ error: "Plan not found" }, { status: 404 });
     }
 
+    const planCharactersQuery = db
+      .select({
+        id: raidPlanCharacters.id,
+        characterId: raidPlanCharacters.characterId,
+        characterName: raidPlanCharacters.characterName,
+        defaultGroup: raidPlanCharacters.defaultGroup,
+        defaultPosition: raidPlanCharacters.defaultPosition,
+        class: sql<
+          string | null
+        >`COALESCE(${characters.class}, ${raidPlanCharacters.writeInClass})`,
+      })
+      .from(raidPlanCharacters)
+      .leftJoin(characters, eq(raidPlanCharacters.characterId, characters.characterId))
+      .where(eq(raidPlanCharacters.raidPlanId, id))
+      .orderBy(
+        raidPlanCharacters.defaultGroup,
+        raidPlanCharacters.defaultPosition,
+        raidPlanCharacters.characterName,
+        raidPlanCharacters.id,
+      );
+
+    const encountersQuery = db
+      .select({
+        id: raidPlanEncounters.id,
+        encounterKey: raidPlanEncounters.encounterKey,
+        encounterName: raidPlanEncounters.encounterName,
+        sortOrder: raidPlanEncounters.sortOrder,
+        groupId: raidPlanEncounters.groupId,
+        useDefaultGroups: raidPlanEncounters.useDefaultGroups,
+        aaTemplate: raidPlanEncounters.aaTemplate,
+        useCustomAA: raidPlanEncounters.useCustomAA,
+      })
+      .from(raidPlanEncounters)
+      .where(eq(raidPlanEncounters.raidPlanId, id))
+      .orderBy(raidPlanEncounters.sortOrder);
+
+    const encounterGroupsQuery = db
+      .select({
+        id: raidPlanEncounterGroups.id,
+        groupName: raidPlanEncounterGroups.groupName,
+        sortOrder: raidPlanEncounterGroups.sortOrder,
+      })
+      .from(raidPlanEncounterGroups)
+      .where(eq(raidPlanEncounterGroups.raidPlanId, id))
+      .orderBy(raidPlanEncounterGroups.sortOrder);
+
     const [planCharacters, encounters, encounterGroups] = await Promise.all([
-      db
-        .select({
-          id: raidPlanCharacters.id,
-          characterId: raidPlanCharacters.characterId,
-          characterName: raidPlanCharacters.characterName,
-          defaultGroup: raidPlanCharacters.defaultGroup,
-          defaultPosition: raidPlanCharacters.defaultPosition,
-          class: sql<
-            string | null
-          >`COALESCE(${characters.class}, ${raidPlanCharacters.writeInClass})`,
-        })
-        .from(raidPlanCharacters)
-        .leftJoin(characters, eq(raidPlanCharacters.characterId, characters.characterId))
-        .where(eq(raidPlanCharacters.raidPlanId, id))
-        .orderBy(
-          raidPlanCharacters.defaultGroup,
-          raidPlanCharacters.defaultPosition,
-          raidPlanCharacters.characterName,
-          raidPlanCharacters.id,
-        ),
-      db
-        .select({
-          id: raidPlanEncounters.id,
-          encounterKey: raidPlanEncounters.encounterKey,
-          encounterName: raidPlanEncounters.encounterName,
-          sortOrder: raidPlanEncounters.sortOrder,
-          groupId: raidPlanEncounters.groupId,
-          useDefaultGroups: raidPlanEncounters.useDefaultGroups,
-          aaTemplate: raidPlanEncounters.aaTemplate,
-          useCustomAA: raidPlanEncounters.useCustomAA,
-        })
-        .from(raidPlanEncounters)
-        .where(eq(raidPlanEncounters.raidPlanId, id))
-        .orderBy(raidPlanEncounters.sortOrder),
-      db
-        .select({
-          id: raidPlanEncounterGroups.id,
-          groupName: raidPlanEncounterGroups.groupName,
-          sortOrder: raidPlanEncounterGroups.sortOrder,
-        })
-        .from(raidPlanEncounterGroups)
-        .where(eq(raidPlanEncounterGroups.raidPlanId, id))
-        .orderBy(raidPlanEncounterGroups.sortOrder),
+      planCharactersQuery,
+      encountersQuery,
+      compact ? Promise.resolve([]) : encounterGroupsQuery,
     ]);
 
     const customEncounterIds = encounters.filter((e) => !e.useDefaultGroups).map((e) => e.id);
@@ -152,9 +162,27 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       .orderBy(raidPlanEncounterAASlots.sortOrder);
 
     const p = plan[0]!;
+    const planUrl = `${getBaseUrl(request)}/raid-manager/raid-planner/${p.id}`;
+
+    if (compact) {
+      return NextResponse.json({
+        id: p.id,
+        name: p.name,
+        planUrl,
+        zoneId: p.zoneId,
+        startAt: p.startAt?.toISOString() ?? null,
+        lastModifiedAt: new Date(p.lastModifiedAt).toISOString(),
+        characters: planCharacters,
+        encounters: encounters.map((e) => ({ id: e.id, encounterName: e.encounterName })),
+        encounterAssignments,
+        aaSlotAssignments,
+      });
+    }
+
     return NextResponse.json({
       id: p.id,
       name: p.name,
+      planUrl,
       zoneId: p.zoneId,
       raidHelperEventId: p.raidHelperEventId,
       startAt: p.startAt?.toISOString() ?? null,

--- a/src/lib/openapi-registry.ts
+++ b/src/lib/openapi-registry.ts
@@ -232,12 +232,49 @@ const AASlotAssignmentSchema = z.object({
 export const RaidPlanDetailSchema = registry.register(
   "RaidPlanDetail",
   RaidPlanSummarySchema.extend({
+    planUrl: z.string().url().openapi({
+      example:
+        "https://www.temple-era.com/raid-manager/raid-planner/a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    }),
     defaultAATemplate: z.string().nullable().openapi({ example: null }),
     useDefaultAA: z.boolean().nullable().openapi({ example: true }),
     availableSlots: z.array(z.string()).openapi({ example: ["MainTank", "TranqShot1", "Healer1"] }),
     characters: z.array(PlanCharacterSchema),
     encounterGroups: z.array(EncounterGroupSchema),
     encounters: z.array(EncounterSchema),
+    encounterAssignments: z.array(EncounterAssignmentSchema),
+    aaSlotAssignments: z.array(AASlotAssignmentSchema),
+  }),
+);
+
+const CompactEncounterSchema = z.object({
+  id: z.string().uuid().openapi({ example: "c3d4e5f6-a7b8-9012-cdef-123456789012" }),
+  encounterName: z.string().openapi({ example: "Patchwerk" }),
+});
+
+const CompactPlanCharacterSchema = z.object({
+  id: z.string().uuid().openapi({ example: "b2c3d4e5-f601-7890-abcd-ef1234567890" }),
+  characterId: z.number().nullable().openapi({ example: 12345 }),
+  characterName: z.string().openapi({ example: "Khlav" }),
+  class: z.string().nullable().openapi({ example: "Warrior" }),
+  defaultGroup: z.number().nullable().openapi({ example: 0 }),
+  defaultPosition: z.number().nullable().openapi({ example: 0 }),
+});
+
+export const RaidPlanCompactSchema = registry.register(
+  "RaidPlanCompact",
+  z.object({
+    id: z.string().uuid().openapi({ example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" }),
+    name: z.string().openapi({ example: "MC Tuesday" }),
+    planUrl: z.string().url().openapi({
+      example:
+        "https://www.temple-era.com/raid-manager/raid-planner/a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    }),
+    zoneId: z.string().openapi({ example: "naxxramas" }),
+    startAt: z.string().nullable().openapi({ example: "2026-04-29T23:00:00.000Z" }),
+    lastModifiedAt: z.string().openapi({ example: "2026-04-28T14:30:00.000Z" }),
+    characters: z.array(CompactPlanCharacterSchema),
+    encounters: z.array(CompactEncounterSchema),
     encounterAssignments: z.array(EncounterAssignmentSchema),
     aaSlotAssignments: z.array(AASlotAssignmentSchema),
   }),
@@ -588,16 +625,24 @@ registry.registerPath({
   tags: ["Raid Planning"],
   summary: "Get raid plan detail",
   description:
-    "Full plan detail including roster, encounters, per-encounter group assignments, and AA slot assignments. Requires isRaidManager.",
+    "Full plan detail including roster, encounters, per-encounter group assignments, and AA slot assignments. Pass `?compact=true` to get a trimmed payload with only roster and AA assignment data (omits encounter templates, group config, and other heavy metadata). Both shapes include `planUrl`. Requires isRaidManager.",
   security: [{ BearerToken: [] }],
   request: {
     params: z.object({
       id: z.string().uuid().openapi({ example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" }),
     }),
+    query: z.object({
+      compact: z.enum(["true", "false"]).optional().openapi({
+        description:
+          "When true, returns a trimmed payload (roster + AA assignments only, no encounter templates or group config). Default: false.",
+        example: "true",
+      }),
+    }),
   },
   responses: {
     200: {
-      description: "Full raid plan detail",
+      description:
+        "Full raid plan detail (or compact subset when ?compact=true — see RaidPlanCompact schema)",
       content: {
         "application/json": { schema: RaidPlanDetailSchema },
       },


### PR DESCRIPTION
Closes #233, closes #232

### Features + updates

- _GET /api/v1/raid-plans/:id_ now returns a _planUrl_ field linking directly to the web planner view
- New _?compact=true_ query parameter returns a trimmed payload (roster + AA assignments only) — useful for bots and tooling that don't need full encounter templates or group config

### Technical details

- _planUrl_ is present in both full and compact responses; constructed via _getBaseUrl_ so it respects _NEXT_PUBLIC_APP_URL_
- Compact mode skips the encounter groups DB query entirely; encounter data is reduced to id + name only
- _RaidPlanCompact_ schema registered in the OpenAPI spec; _getRaidPlan_ path documents the _compact_ query param