### PR TITLE
Skip type check in Vercel builds (~26s saved)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,10 @@ const config = {
     // ESLint removed in favour of oxlint (runs via lefthook, not next build)
     ignoreDuringBuilds: true,
   },
+  typescript: {
+    // tsc runs in the pre-push hook; skipping the redundant Vercel check saves ~26s
+    ignoreBuildErrors: !!process.env.VERCEL,
+  },
   experimental: {
     optimizePackageImports: ["lucide-react", "date-fns", "date-fns-tz"],
   },


### PR DESCRIPTION
### Technical details

- Sets _typescript.ignoreBuildErrors_ only when _VERCEL=1_ is set, so local builds are unaffected
- _tsc_ already runs in the pre-push hook before any commit reaches Vercel — the Vercel check was redundant
- Expected saving: ~26s per deploy based on build log analysis