### PR TITLE
feat(api): replace compact param with include-based section selection on raid plan GET

### DIFF
--- a/src/app/api/v1/raid-plans/[id]/route.ts
+++ b/src/app/api/v1/raid-plans/[id]/route.ts
@@ -39,8 +39,28 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       return NextResponse.json({ error: "Invalid plan ID" }, { status: 400 });
     }
 
+    const VALID_SECTIONS = [
+      "characters",
+      "encounterGroups",
+      "encounters",
+      "encounterAssignments",
+      "aaSlots",
+    ] as const;
+    type Section = (typeof VALID_SECTIONS)[number];
+
     const url = new URL(request.url);
-    const compact = url.searchParams.get("compact") === "true";
+    const includeParam = url.searchParams.get("include");
+    const requestedSections = new Set<Section>(
+      includeParam === null
+        ? VALID_SECTIONS
+        : includeParam
+            .split(",")
+            .map((s) => s.trim())
+            .filter((s): s is Section => (VALID_SECTIONS as readonly string[]).includes(s)),
+    );
+    if (requestedSections.has("aaSlots") || requestedSections.has("encounterAssignments")) {
+      requestedSections.add("encounters");
+    }
 
     const plan = await db
       .select({
@@ -61,6 +81,9 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
     if (plan.length === 0) {
       return NextResponse.json({ error: "Plan not found" }, { status: 404 });
     }
+
+    const p = plan[0]!;
+    const planUrl = `${getBaseUrl(request)}/raid-manager/raid-planner/${p.id}`;
 
     const planCharactersQuery = db
       .select({
@@ -109,12 +132,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       .orderBy(raidPlanEncounterGroups.sortOrder);
 
     const [planCharacters, encounters, encounterGroups] = await Promise.all([
-      planCharactersQuery,
-      encountersQuery,
-      compact ? Promise.resolve([]) : encounterGroupsQuery,
+      requestedSections.has("characters") ? planCharactersQuery : Promise.resolve([]),
+      requestedSections.has("encounters") ? encountersQuery : Promise.resolve([]),
+      requestedSections.has("encounterGroups") ? encounterGroupsQuery : Promise.resolve([]),
     ]);
-
-    const customEncounterIds = encounters.filter((e) => !e.useDefaultGroups).map((e) => e.id);
 
     let encounterAssignments: {
       encounterId: string;
@@ -123,60 +144,54 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       position: number | null;
     }[] = [];
 
-    if (customEncounterIds.length > 0) {
-      encounterAssignments = await db
-        .select({
-          encounterId: raidPlanEncounterAssignments.encounterId,
-          planCharacterId: raidPlanEncounterAssignments.planCharacterId,
-          groupNumber: raidPlanEncounterAssignments.groupNumber,
-          position: raidPlanEncounterAssignments.position,
-        })
-        .from(raidPlanEncounterAssignments)
-        .where(inArray(raidPlanEncounterAssignments.encounterId, customEncounterIds))
-        .orderBy(
-          raidPlanEncounterAssignments.encounterId,
-          raidPlanEncounterAssignments.groupNumber,
-          raidPlanEncounterAssignments.position,
-        );
+    if (requestedSections.has("encounterAssignments")) {
+      const customEncounterIds = encounters.filter((e) => !e.useDefaultGroups).map((e) => e.id);
+      if (customEncounterIds.length > 0) {
+        encounterAssignments = await db
+          .select({
+            encounterId: raidPlanEncounterAssignments.encounterId,
+            planCharacterId: raidPlanEncounterAssignments.planCharacterId,
+            groupNumber: raidPlanEncounterAssignments.groupNumber,
+            position: raidPlanEncounterAssignments.position,
+          })
+          .from(raidPlanEncounterAssignments)
+          .where(inArray(raidPlanEncounterAssignments.encounterId, customEncounterIds))
+          .orderBy(
+            raidPlanEncounterAssignments.encounterId,
+            raidPlanEncounterAssignments.groupNumber,
+            raidPlanEncounterAssignments.position,
+          );
+      }
     }
 
-    const encounterIds = encounters.map((e) => e.id);
+    let aaSlotAssignments: {
+      id: string;
+      encounterId: string | null;
+      raidPlanId: string | null;
+      planCharacterId: string | null;
+      slotName: string;
+    }[] = [];
 
-    const aaSlotAssignments = await db
-      .select({
-        id: raidPlanEncounterAASlots.id,
-        encounterId: raidPlanEncounterAASlots.encounterId,
-        raidPlanId: raidPlanEncounterAASlots.raidPlanId,
-        planCharacterId: raidPlanEncounterAASlots.planCharacterId,
-        slotName: raidPlanEncounterAASlots.slotName,
-      })
-      .from(raidPlanEncounterAASlots)
-      .where(
-        or(
-          eq(raidPlanEncounterAASlots.raidPlanId, id),
-          encounterIds.length > 0
-            ? inArray(raidPlanEncounterAASlots.encounterId, encounterIds)
-            : undefined,
-        ),
-      )
-      .orderBy(raidPlanEncounterAASlots.sortOrder);
-
-    const p = plan[0]!;
-    const planUrl = `${getBaseUrl(request)}/raid-manager/raid-planner/${p.id}`;
-
-    if (compact) {
-      return NextResponse.json({
-        id: p.id,
-        name: p.name,
-        planUrl,
-        zoneId: p.zoneId,
-        startAt: p.startAt?.toISOString() ?? null,
-        lastModifiedAt: new Date(p.lastModifiedAt).toISOString(),
-        characters: planCharacters,
-        encounters: encounters.map((e) => ({ id: e.id, encounterName: e.encounterName })),
-        encounterAssignments,
-        aaSlotAssignments,
-      });
+    if (requestedSections.has("aaSlots")) {
+      const encounterIds = encounters.map((e) => e.id);
+      aaSlotAssignments = await db
+        .select({
+          id: raidPlanEncounterAASlots.id,
+          encounterId: raidPlanEncounterAASlots.encounterId,
+          raidPlanId: raidPlanEncounterAASlots.raidPlanId,
+          planCharacterId: raidPlanEncounterAASlots.planCharacterId,
+          slotName: raidPlanEncounterAASlots.slotName,
+        })
+        .from(raidPlanEncounterAASlots)
+        .where(
+          or(
+            eq(raidPlanEncounterAASlots.raidPlanId, id),
+            encounterIds.length > 0
+              ? inArray(raidPlanEncounterAASlots.encounterId, encounterIds)
+              : undefined,
+          ),
+        )
+        .orderBy(raidPlanEncounterAASlots.sortOrder);
     }
 
     return NextResponse.json({
@@ -191,14 +206,16 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       useDefaultAA: p.useDefaultAA,
       lastModifiedAt: new Date(p.lastModifiedAt).toISOString(),
       availableSlots: getSlotNames(p.defaultAATemplate ?? ""),
-      characters: planCharacters,
-      encounterGroups,
-      encounters: encounters.map((e) => ({
-        ...e,
-        availableSlots: getSlotNames(e.aaTemplate ?? ""),
-      })),
-      encounterAssignments,
-      aaSlotAssignments,
+      ...(requestedSections.has("characters") && { characters: planCharacters }),
+      ...(requestedSections.has("encounterGroups") && { encounterGroups }),
+      ...(requestedSections.has("encounters") && {
+        encounters: encounters.map((e) => ({
+          ...e,
+          availableSlots: getSlotNames(e.aaTemplate ?? ""),
+        })),
+      }),
+      ...(requestedSections.has("encounterAssignments") && { encounterAssignments }),
+      ...(requestedSections.has("aaSlots") && { aaSlotAssignments }),
     });
   } catch (error) {
     logger.error({ err: error }, "v1 API error");

--- a/src/lib/openapi-registry.ts
+++ b/src/lib/openapi-registry.ts
@@ -239,44 +239,11 @@ export const RaidPlanDetailSchema = registry.register(
     defaultAATemplate: z.string().nullable().openapi({ example: null }),
     useDefaultAA: z.boolean().nullable().openapi({ example: true }),
     availableSlots: z.array(z.string()).openapi({ example: ["MainTank", "TranqShot1", "Healer1"] }),
-    characters: z.array(PlanCharacterSchema),
-    encounterGroups: z.array(EncounterGroupSchema),
-    encounters: z.array(EncounterSchema),
-    encounterAssignments: z.array(EncounterAssignmentSchema),
-    aaSlotAssignments: z.array(AASlotAssignmentSchema),
-  }),
-);
-
-const CompactEncounterSchema = z.object({
-  id: z.string().uuid().openapi({ example: "c3d4e5f6-a7b8-9012-cdef-123456789012" }),
-  encounterName: z.string().openapi({ example: "Patchwerk" }),
-});
-
-const CompactPlanCharacterSchema = z.object({
-  id: z.string().uuid().openapi({ example: "b2c3d4e5-f601-7890-abcd-ef1234567890" }),
-  characterId: z.number().nullable().openapi({ example: 12345 }),
-  characterName: z.string().openapi({ example: "Khlav" }),
-  class: z.string().nullable().openapi({ example: "Warrior" }),
-  defaultGroup: z.number().nullable().openapi({ example: 0 }),
-  defaultPosition: z.number().nullable().openapi({ example: 0 }),
-});
-
-export const RaidPlanCompactSchema = registry.register(
-  "RaidPlanCompact",
-  z.object({
-    id: z.string().uuid().openapi({ example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" }),
-    name: z.string().openapi({ example: "MC Tuesday" }),
-    planUrl: z.string().url().openapi({
-      example:
-        "https://www.temple-era.com/raid-manager/raid-planner/a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-    }),
-    zoneId: z.string().openapi({ example: "naxxramas" }),
-    startAt: z.string().nullable().openapi({ example: "2026-04-29T23:00:00.000Z" }),
-    lastModifiedAt: z.string().openapi({ example: "2026-04-28T14:30:00.000Z" }),
-    characters: z.array(CompactPlanCharacterSchema),
-    encounters: z.array(CompactEncounterSchema),
-    encounterAssignments: z.array(EncounterAssignmentSchema),
-    aaSlotAssignments: z.array(AASlotAssignmentSchema),
+    characters: z.array(PlanCharacterSchema).optional(),
+    encounterGroups: z.array(EncounterGroupSchema).optional(),
+    encounters: z.array(EncounterSchema).optional(),
+    encounterAssignments: z.array(EncounterAssignmentSchema).optional(),
+    aaSlotAssignments: z.array(AASlotAssignmentSchema).optional(),
   }),
 );
 
@@ -625,24 +592,24 @@ registry.registerPath({
   tags: ["Raid Planning"],
   summary: "Get raid plan detail",
   description:
-    "Full plan detail including roster, encounters, per-encounter group assignments, and AA slot assignments. Pass `?compact=true` to get a trimmed payload with only roster and AA assignment data (omits encounter templates, group config, and other heavy metadata). Both shapes include `planUrl`. Requires isRaidManager.",
+    "Full plan detail including roster, encounters, per-encounter group assignments, and AA slot assignments. Metadata fields are always returned. Use `?include=` to request only specific sections; omit to receive all sections. Requires isRaidManager.",
   security: [{ BearerToken: [] }],
   request: {
     params: z.object({
       id: z.string().uuid().openapi({ example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" }),
     }),
     query: z.object({
-      compact: z.enum(["true", "false"]).optional().openapi({
+      include: z.string().optional().openapi({
         description:
-          "When true, returns a trimmed payload (roster + AA assignments only, no encounter templates or group config). Default: false.",
-        example: "true",
+          "Comma-separated list of sections to include. Valid values: characters, encounterGroups, encounters, encounterAssignments, aaSlots. Omit to return all sections. Note: encounterAssignments and aaSlots implicitly include encounters for ID resolution.",
+        example: "characters,aaSlots",
       }),
     }),
   },
   responses: {
     200: {
       description:
-        "Full raid plan detail (or compact subset when ?compact=true — see RaidPlanCompact schema)",
+        "Plan metadata plus any requested sections. Section arrays are absent when not requested.",
       content: {
         "application/json": { schema: RaidPlanDetailSchema },
       },


### PR DESCRIPTION
Replace the boolean _compact_ query param on _GET /api/v1/raid-plans/{id}_ with a flexible _?include=_ param for opt-in section selection.

### Features + updates

- Callers now request only the data sections they need: _characters_, _encounterGroups_, _encounters_, _encounterAssignments_, _aaSlots_
- Omitting _include_ returns all sections (backward compatible default)
- DB queries are skipped entirely for unrequested sections — the previously unconditional _aaSlotAssignments_ query is now gated

### Technical details

- Removed _compact_ param and all compact-specific schemas (_RaidPlanCompact_, _CompactEncounterSchema_, _CompactPlanCharacterSchema_) from the OpenAPI registry
- Section arrays marked _.optional()_ in _RaidPlanDetailSchema_ to correctly reflect conditional presence in the generated spec
- _encounterAssignments_ and _aaSlots_ implicitly pull in the _encounters_ query for ID resolution, but only include _encounters_ in the response if explicitly requested