### PR TITLE
chore(api): improve include param OpenAPI spec with enum and form/no-explode style

### DIFF
--- a/src/lib/openapi-registry.ts
+++ b/src/lib/openapi-registry.ts
@@ -599,11 +599,23 @@ registry.registerPath({
       id: z.string().uuid().openapi({ example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890" }),
     }),
     query: z.object({
-      include: z.string().optional().openapi({
-        description:
-          "Comma-separated list of sections to include. Valid values: characters, encounterGroups, encounters, encounterAssignments, aaSlots. Omit to return all sections. Note: encounterAssignments and aaSlots implicitly include encounters for ID resolution.",
-        example: "characters,aaSlots",
-      }),
+      include: z
+        .array(
+          z.enum([
+            "characters",
+            "encounterGroups",
+            "encounters",
+            "encounterAssignments",
+            "aaSlots",
+          ]),
+        )
+        .optional()
+        .openapi({
+          param: { style: "form", explode: false },
+          description:
+            "Sections to include. Omit to return all sections. encounterAssignments and aaSlots implicitly resolve encounters for ID lookups.",
+          example: ["characters", "aaSlots"],
+        }),
     }),
   },
   responses: {


### PR DESCRIPTION
Improves the OpenAPI spec for the _?include=_ query param on _GET /api/v1/raid-plans/{id}_.

### Technical details

- Changed from _z.string()_ to _z.array(z.enum([...]))_ so valid section values are machine-readable in the spec
- Added _style: form, explode: false_ to correctly document comma-separated serialization (vs the default repeated-key array style)
- Verified generated spec has _schema.items.enum_, _style_, and _explode_ on the Parameter Object