### PR TITLE
chore(api): characters always returned by default, include selects additional sections

### DIFF
--- a/src/app/api/v1/raid-plans/[id]/route.ts
+++ b/src/app/api/v1/raid-plans/[id]/route.ts
@@ -39,24 +39,25 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       return NextResponse.json({ error: "Invalid plan ID" }, { status: 400 });
     }
 
-    const VALID_SECTIONS = [
-      "characters",
+    const OPTIONAL_SECTIONS = [
       "encounterGroups",
       "encounters",
       "encounterAssignments",
       "aaSlots",
     ] as const;
-    type Section = (typeof VALID_SECTIONS)[number];
+    type OptionalSection = (typeof OPTIONAL_SECTIONS)[number];
 
     const url = new URL(request.url);
     const includeParam = url.searchParams.get("include");
-    const requestedSections = new Set<Section>(
+    const requestedSections = new Set<OptionalSection>(
       includeParam === null
-        ? VALID_SECTIONS
+        ? []
         : includeParam
             .split(",")
             .map((s) => s.trim())
-            .filter((s): s is Section => (VALID_SECTIONS as readonly string[]).includes(s)),
+            .filter((s): s is OptionalSection =>
+              (OPTIONAL_SECTIONS as readonly string[]).includes(s),
+            ),
     );
     if (requestedSections.has("aaSlots") || requestedSections.has("encounterAssignments")) {
       requestedSections.add("encounters");
@@ -132,7 +133,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       .orderBy(raidPlanEncounterGroups.sortOrder);
 
     const [planCharacters, encounters, encounterGroups] = await Promise.all([
-      requestedSections.has("characters") ? planCharactersQuery : Promise.resolve([]),
+      planCharactersQuery,
       requestedSections.has("encounters") ? encountersQuery : Promise.resolve([]),
       requestedSections.has("encounterGroups") ? encounterGroupsQuery : Promise.resolve([]),
     ]);
@@ -206,7 +207,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       useDefaultAA: p.useDefaultAA,
       lastModifiedAt: new Date(p.lastModifiedAt).toISOString(),
       availableSlots: getSlotNames(p.defaultAATemplate ?? ""),
-      ...(requestedSections.has("characters") && { characters: planCharacters }),
+      characters: planCharacters,
       ...(requestedSections.has("encounterGroups") && { encounterGroups }),
       ...(requestedSections.has("encounters") && {
         encounters: encounters.map((e) => ({

--- a/src/lib/openapi-registry.ts
+++ b/src/lib/openapi-registry.ts
@@ -239,7 +239,7 @@ export const RaidPlanDetailSchema = registry.register(
     defaultAATemplate: z.string().nullable().openapi({ example: null }),
     useDefaultAA: z.boolean().nullable().openapi({ example: true }),
     availableSlots: z.array(z.string()).openapi({ example: ["MainTank", "TranqShot1", "Healer1"] }),
-    characters: z.array(PlanCharacterSchema).optional(),
+    characters: z.array(PlanCharacterSchema),
     encounterGroups: z.array(EncounterGroupSchema).optional(),
     encounters: z.array(EncounterSchema).optional(),
     encounterAssignments: z.array(EncounterAssignmentSchema).optional(),
@@ -592,7 +592,7 @@ registry.registerPath({
   tags: ["Raid Planning"],
   summary: "Get raid plan detail",
   description:
-    "Full plan detail including roster, encounters, per-encounter group assignments, and AA slot assignments. Metadata fields are always returned. Use `?include=` to request only specific sections; omit to receive all sections. Requires isRaidManager.",
+    "Plan detail. Metadata and roster (characters) are always returned. Use `?include=` to request additional sections: encounterGroups, encounters, encounterAssignments, aaSlots. Requires isRaidManager.",
   security: [{ BearerToken: [] }],
   request: {
     params: z.object({
@@ -600,21 +600,13 @@ registry.registerPath({
     }),
     query: z.object({
       include: z
-        .array(
-          z.enum([
-            "characters",
-            "encounterGroups",
-            "encounters",
-            "encounterAssignments",
-            "aaSlots",
-          ]),
-        )
+        .array(z.enum(["encounterGroups", "encounters", "encounterAssignments", "aaSlots"]))
         .optional()
         .openapi({
           param: { style: "form", explode: false },
           description:
-            "Sections to include. Omit to return all sections. encounterAssignments and aaSlots implicitly resolve encounters for ID lookups.",
-          example: ["characters", "aaSlots"],
+            "Optional sections to include beyond the default roster. encounterAssignments and aaSlots implicitly resolve encounters for ID lookups.",
+          example: ["encounters", "aaSlots"],
         }),
     }),
   },


### PR DESCRIPTION
Adjusts the default behavior of _GET /api/v1/raid-plans/{id}_ so the roster is always included, and _?include=_ opts into the heavier sections only.

### Features + updates

- _characters_ (roster) is now always returned — no longer an _include_ option
- _?include=_ enum is now _encounterGroups_, _encounters_, _encounterAssignments_, _aaSlots_
- Omitting _include_ returns metadata + roster only (lightweight default)
- OpenAPI spec updated: _characters_ marked required in response schema, enum values updated