### PR TITLE
Fix Supabase connection pooling on Vercel

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,13 +1,8 @@
 import pino from "pino";
+import pinoPretty from "pino-pretty";
 
 const isDev = process.env.NODE_ENV === "development";
 
-export const logger = pino({
-  level: isDev ? "debug" : "info",
-  ...(isDev && {
-    transport: {
-      target: "pino-pretty",
-      options: { colorize: true },
-    },
-  }),
-});
+export const logger = isDev
+  ? pino({ level: "debug" }, pinoPretty({ colorize: true }))
+  : pino({ level: "info" });

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -16,10 +16,11 @@ const globalForDb = globalThis as unknown as {
 const conn =
   globalForDb.conn ??
   postgres(env.DATABASE_URL, {
-    max: 3,
+    prepare: false,
+    max: 10,
     connect_timeout: 10,
     max_lifetime: 60 * 5,
-    idle_timeout: 20,
+    idle_timeout: 0,
   });
 if (env.NODE_ENV !== "production") globalForDb.conn = conn;
 


### PR DESCRIPTION
Fixes persistent connection issues with Supabase + Drizzle on Vercel that caused queries to hang or the connection pool to clog over time.

### Fixes

- Queries no longer hang after the first successful page load
- Connection pool no longer clogs after a few days on session pooler
- tRPC route no longer crashes on load due to pino worker thread error under Turbopack

### Technical details

- _src/server/db/index.ts_: switched to transaction pooler with _prepare: false_ (required for PgBouncer transaction mode), _max: 10_ (safe with transaction pooler; connections are returned per-transaction), and _idle_timeout: 0_ (prevents client sockets from dying mid-flight and leaving stuck backend connections)
- _src/lib/logger.ts_: replaced pino _transport_ option (spawns a worker thread with a Turbopack-mangled path) with a direct _pino-pretty_ stream — no worker thread needed
- Requires _DATABASE_URL_ to point to the Supabase transaction pooler (port 6543) with _?pgbouncer=true_ removed