### PR TITLE
Add pnpm db:clone-prod command and reorganize env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,39 +1,12 @@
-# When adding additional environment variables, the schema in "/src/env.js"
-# should be updated accordingly.
+# When adding environment variables, update the schema in /src/env.js accordingly.
 
-# Next Auth
-# You can generate a new secret on the command line with:
-# npx auth secret
-# https://next-auth.js.org/configuration/options\#secret
-AUTH_SECRET="your_auth_secret_here" # Generate with: npx auth secret
-
-# Next Auth Discord Provider
+# Authentication
+AUTH_SECRET="your_auth_secret_here"    # Generate: npx auth secret
 AUTH_DISCORD_ID="your_discord_client_id"
 AUTH_DISCORD_SECRET="your_discord_client_secret"
 
-# Discord Bot + Raidlog Watching
-DISCORD_BOT_TOKEN=your_discord_bot_token
-DISCORD_RAID_LOGS_CHANNEL_ID=your_channel_id
-DISCORD_RAID_SR_CHANNEL_IDS=channel_id_1,channel_id_2,channel_id_3
-DISCORD_RAID_HELPER_BOT_ID=579155972115660803
-DISCORD_WEBHOOK_PUBLIC_KEY=your_webhook_public_key
-
-# Discord Bot + Website communication
-TEMPLE_WEB_API_TOKEN="your_api_token"
-
-# AES-256-GCM key for encrypting API tokens (for Templar proxy). Generate with:
-# node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
-API_TOKEN_ENCRYPTION_KEY=
-
-# Raid-Helper Integration
-DISCORD_SERVER_ID=your_discord_server_id
-RAID_HELPER_API_KEY=your_raid_helper_api_key
-
-# Drizzle
-# LOCAL: 
-# DATABASE_URL="postgresql://postgres:password@localhost:5432/temple-raid-t3"
-# Neon local-dev branch
-DATABASE_URL="postgresql://username:password@hostname:5432/database?sslmode=require&channel_binding=require"
+# Database
+DATABASE_URL="postgresql://username:password@hostname:6543/database"
 
 # WarcraftLogs
 WCL_OAUTH_URL="https://vanilla.warcraftlogs.com/oauth/token"
@@ -41,15 +14,35 @@ WCL_API_URL="https://vanilla.warcraftlogs.com/api/v2/client"
 WCL_CLIENT_ID="your_wcl_client_id"
 WCL_CLIENT_SECRET="your_wcl_client_secret"
 
-# BlizzardDev
+# Battle.net
 BATTLENET_OAUTH_URL="https://oauth.battle.net/token"
 BATTLENET_CLIENT_ID="your_battlenet_client_id"
 BATTLENET_CLIENT_SECRET="your_battlenet_client_secret"
 
-# Posthog
-NEXT_PUBLIC_POSTHOG_ENABLED=false
-NEXT_PUBLIC_POSTHOG_KEY=your_posthog_key
-NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.co
+# Discord
+DISCORD_SERVER_ID="your_discord_server_id"
+DISCORD_BOT_TOKEN="your_discord_bot_token"
+DISCORD_RAID_LOGS_CHANNEL_ID="your_channel_id"
+DISCORD_RAID_SR_CHANNEL_IDS="channel_id_1,channel_id_2,channel_id_3"
+DISCORD_WEBHOOK_PUBLIC_KEY="your_webhook_public_key"
+TEMPLE_WEB_API_TOKEN="your_api_token"
 
-# Restricted Naxx Items Spreadsheet
+# Raid Helper
+DISCORD_RAID_HELPER_BOT_ID="579155972115660803"
+RAID_HELPER_API_KEY="your_raid_helper_api_key"
+
+# Security
+API_TOKEN_ENCRYPTION_KEY=""    # Generate: node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
+
+# Analytics (optional)
+NEXT_PUBLIC_POSTHOG_ENABLED="false"
+NEXT_PUBLIC_POSTHOG_KEY="your_posthog_key"
+NEXT_PUBLIC_POSTHOG_HOST="https://us.i.posthog.co"
+
+# App (optional)
+NEXT_PUBLIC_APP_URL="https://your-app-url.com"
 NEXT_PUBLIC_RESTRICTED_NAXX_ITEMS_URL="https://docs.google.com/spreadsheets/d/1OBcFgT1AXiPL3eW7x3yUx6EjsopPLlFMclph2OGRkXU/edit"
+GOOGLE_SITE_VERIFICATION="your_google_site_verification_token"
+
+# Development
+DATABASE_PROD_URL="postgresql://username:password@hostname:6543/database"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,16 @@ pnpm db:migrate       # Run migrations
 pnpm db:studio        # Open Drizzle Studio (database GUI)
 ```
 
+### Cloning PROD to DEV
+
+Copies all application data from PROD to DEV. Only app-owned schemas (`public`, `views`, `drizzle`) are dumped — Supabase-managed schemas are excluded entirely.
+
+**Prerequisites:** `pg_dump`, `pg_restore`, and `psql` must be v17 to match the server. Set `DATABASE_PROD_URL` in `.env`.
+
+```bash
+pnpm db:clone-prod
+```
+
 ### Code Quality Commands
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
+    "db:clone-prod": "bash scripts/db/clone-prod.sh",
     "db:migration:compare": "bash scripts/db/compare-row-counts.sh",
     "db:migration:dump:data": "bash scripts/db/dump.sh data-only",
     "db:migration:dump:full": "bash scripts/db/dump.sh full",

--- a/scripts/db/clone-prod.sh
+++ b/scripts/db/clone-prod.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_lib.sh"
+
+load_env_files
+require_command pg_dump
+require_command pg_restore
+require_command psql
+
+PROD_DB_URL="$(resolve_url_from_env "DATABASE_PROD_URL")"
+DEV_DB_URL="$(resolve_url_from_env "DATABASE_URL")"
+
+DUMP_FILE="$(mktemp /tmp/prod-clone.XXXXXX.dump)"
+TOC_FILE="$(mktemp /tmp/prod-clone.XXXXXX.toc)"
+trap 'rm -f "$DUMP_FILE" "$TOC_FILE"' EXIT
+
+echo "Dumping production database (public, views, drizzle schemas)..."
+pg_dump \
+  --format=custom \
+  --no-owner \
+  --no-privileges \
+  --schema=public \
+  --schema=views \
+  --schema=drizzle \
+  --file="$DUMP_FILE" \
+  "$PROD_DB_URL"
+
+echo "Wiping dev database..."
+psql "$DEV_DB_URL" -c "
+  DROP SCHEMA IF EXISTS public CASCADE;
+  DROP SCHEMA IF EXISTS views CASCADE;
+  DROP SCHEMA IF EXISTS drizzle CASCADE;
+  CREATE SCHEMA public;
+  CREATE SCHEMA views;
+  CREATE SCHEMA drizzle;
+  CREATE EXTENSION IF NOT EXISTS unaccent SCHEMA public;
+  CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\" SCHEMA public;
+"
+
+# Build a filtered TOC that excludes schema/extension creation (already handled above)
+pg_restore --list "$DUMP_FILE" \
+  | grep -v -E "^[0-9]+;.*(SCHEMA|EXTENSION|COMMENT - SCHEMA)" \
+  > "$TOC_FILE"
+
+echo "Restoring into dev database..."
+pg_restore \
+  --dbname="$DEV_DB_URL" \
+  --no-owner \
+  --no-privileges \
+  --use-list="$TOC_FILE" \
+  "$DUMP_FILE"
+
+echo "Clone complete."

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,11 +6,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://www.temple-era.com";
 
   // Fetch all raids for dynamic sitemap
-  const allRaids = await db.select({ id: raids.raidId, date: raids.date }).from(raids);
-
-  // Filter to only include raids from the last 6 months
-  const sixMonthsAgo = new Date(Date.now() - 6 * 30 * 24 * 60 * 60 * 1000);
-  const recentRaids = allRaids.filter((raid) => raid.date && new Date(raid.date) > sixMonthsAgo);
+  let recentRaids: { id: number; date: string | null }[] = [];
+  try {
+    const allRaids = await db.select({ id: raids.raidId, date: raids.date }).from(raids);
+    const sixMonthsAgo = new Date(Date.now() - 6 * 30 * 24 * 60 * 60 * 1000);
+    recentRaids = allRaids.filter((raid) => raid.date && new Date(raid.date) > sixMonthsAgo);
+  } catch {
+    // DB unavailable during build — return static pages only
+  }
 
   const staticPages = [
     {
@@ -33,7 +36,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ];
 
-  // Add individual raid pages for recent raids only
   const raidPages = recentRaids.map((raid) => ({
     url: `${baseUrl}/raids/${raid.id}`,
     lastModified: raid.date ? new Date(raid.date) : new Date(),

--- a/src/env.js
+++ b/src/env.js
@@ -42,6 +42,8 @@ export const env = createEnv({
    */
   client: {
     NEXT_PUBLIC_POSTHOG_ENABLED: z.string().transform((val) => val.toLowerCase() === "true"),
+    NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
+    NEXT_PUBLIC_POSTHOG_HOST: z.string().url().optional(),
     NEXT_PUBLIC_APP_URL: z.string().url().optional(),
     NEXT_PUBLIC_RESTRICTED_NAXX_ITEMS_URL: z.string().url(),
   },
@@ -76,6 +78,8 @@ export const env = createEnv({
     API_TOKEN_ENCRYPTION_KEY: process.env.API_TOKEN_ENCRYPTION_KEY,
 
     NEXT_PUBLIC_POSTHOG_ENABLED: process.env.NEXT_PUBLIC_POSTHOG_ENABLED,
+    NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
+    NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
     NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
     NEXT_PUBLIC_RESTRICTED_NAXX_ITEMS_URL: process.env.NEXT_PUBLIC_RESTRICTED_NAXX_ITEMS_URL,
 


### PR DESCRIPTION
Dev tooling improvements: a clean \`pnpm db:clone-prod\` command for cloning production data to the local dev database, plus reorganized env var documentation.

### Features + updates

- _pnpm db:clone-prod_ — dumps only app-owned schemas (_public_, _views_, _drizzle_) from prod and restores cleanly into dev; zero errors from Supabase-internal schemas
- _DATABASE_PROD_URL_ env var added for the production read connection
- _.env.example_ reorganized into logical sections (Authentication, Database, Discord, Raid Helper, Security, Analytics, App, Development)

### Fixes

- Sitemap degrades gracefully when the database is unavailable during static generation, preventing build failures

### Technical details

- _scripts/db/clone-prod.sh_ follows the existing _scripts/db/_ pattern using _\_lib.sh_
- Wipe step drops _public_/_views_/_drizzle_ schemas and pre-installs extensions (_unaccent_, _uuid-ossp_) that pg_dump omits; TOC filtering prevents pg_restore from re-creating what's already there
- _src/env.js_ now validates _NEXT_PUBLIC_POSTHOG_KEY_ and _NEXT_PUBLIC_POSTHOG_HOST_ (were in _.env.example_ but unvalidated)