### PR TITLE
feat(proxy): add apiVersion support to Discord bot proxy

### DIFF
--- a/src/app/api/discord/proxy/[discordId]/route.ts
+++ b/src/app/api/discord/proxy/[discordId]/route.ts
@@ -10,6 +10,8 @@ import { logger } from "~/lib/logger";
 
 const ALLOWED_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]);
 
+const API_VERSIONS = ["v1", "v2"] as const;
+
 const ProxySchema = z.object({
   method: z
     .string()
@@ -17,14 +19,15 @@ const ProxySchema = z.object({
     .refine((m) => ALLOWED_METHODS.has(m), {
       message: "method must be GET, POST, PUT, PATCH, or DELETE",
     }),
+  apiVersion: z.enum(API_VERSIONS).default("v1"),
   path: z
     .string()
     .min(1)
     .startsWith("/")
     .transform((p) => {
       try {
-        const normalized = new URL(`http://x/api/v1${p}`).pathname;
-        return normalized.slice("/api/v1".length) || "/";
+        const normalized = new URL(`http://x${p}`).pathname;
+        return normalized || "/";
       } catch {
         return p;
       }
@@ -76,7 +79,7 @@ export async function POST(
       );
     }
 
-    const { method, path, body: proxyBody } = parsed.data;
+    const { method, apiVersion, path, body: proxyBody } = parsed.data;
     const { discordId } = await params;
 
     if (!/^\d{17,19}$/.test(discordId)) {
@@ -128,9 +131,9 @@ export async function POST(
       return NextResponse.json({ error: "Failed to decrypt user token" }, { status: 500 });
     }
 
-    // 6. Forward the request to /api/v1
+    // 6. Forward the request to the target API version
     const baseUrl = getBaseUrl(request);
-    const targetUrl = `${baseUrl}/api/v1${path}`;
+    const targetUrl = `${baseUrl}/api/${apiVersion}${path}`;
 
     const proxyHeaders: HeadersInit = {
       Authorization: `Bearer ${plainToken}`,


### PR DESCRIPTION
## Summary

- Adds optional _apiVersion_ field (default: _"v1"_) to the Discord bot proxy endpoint _POST /api/discord/proxy/{discordId}_
- Existing callers are unaffected — omitting _apiVersion_ behaves exactly as before (routes to _/api/v1_)
- Pass _"apiVersion": "v2"_ with _"path": "/graphql"_ to forward GraphQL queries on behalf of the user

## Test plan

- [ ] Proxy call without _apiVersion_ routes to v1 as before
- [ ] Proxy call with `"apiVersion": "v1"` routes to v1
- [ ] Proxy call with `"apiVersion": "v2"` and `"path": "/graphql"` forwards GraphQL query and returns data
- [ ] Invalid _apiVersion_ value returns 400 validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)