### PR TITLE
feat(graphql): accept bot service token for v2 GraphQL auth

### DIFF
--- a/src/server/api/v2/context.ts
+++ b/src/server/api/v2/context.ts
@@ -4,6 +4,7 @@ import { GraphQLError } from "graphql";
 import { eq } from "drizzle-orm";
 import { db } from "~/server/db";
 import { users } from "~/server/db/schema";
+import { env } from "~/env.js";
 
 export type AuthUser = {
   id: string;
@@ -16,13 +17,21 @@ export type AuthUser = {
 
 export type Context = {
   user: AuthUser | null;
+  /** True when authenticated via the bot service token (TEMPLE_WEB_API_TOKEN). */
+  isServiceAuth: boolean;
   db: typeof db;
 };
 
-async function resolveUser(request: Request): Promise<AuthUser | null> {
+async function resolveAuth(
+  request: Request,
+): Promise<{ user: AuthUser | null; isServiceAuth: boolean }> {
   const authHeader = request.headers.get("authorization");
   const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7).trim() : null;
-  if (!token) return null;
+  if (!token) return { user: null, isServiceAuth: false };
+
+  if (token === env.TEMPLE_WEB_API_TOKEN) {
+    return { user: null, isServiceAuth: true };
+  }
 
   const tokenHash = createHash("sha256").update(token).digest("hex");
   const result = await db
@@ -38,17 +47,17 @@ async function resolveUser(request: Request): Promise<AuthUser | null> {
     .where(eq(users.apiToken, tokenHash))
     .limit(1);
 
-  return result[0] ?? null;
+  return { user: result[0] ?? null, isServiceAuth: false };
 }
 
 export async function buildContext({ request }: { request: Request }): Promise<Context> {
-  const user = await resolveUser(request);
-  return { user, db };
+  const { user, isServiceAuth } = await resolveAuth(request);
+  return { user, isServiceAuth, db };
 }
 
-/** Throws UNAUTHENTICATED if no valid token was provided. */
-export function requireUser(ctx: Context): AuthUser {
-  if (!ctx.user) {
+/** Throws UNAUTHENTICATED if neither a valid user token nor the bot service token was provided. */
+export function requireUser(ctx: Context): AuthUser | null {
+  if (!ctx.user && !ctx.isServiceAuth) {
     throw new GraphQLError("Not authenticated", {
       extensions: { code: "UNAUTHENTICATED" },
     });


### PR DESCRIPTION
## Summary

- The v2 GraphQL API now accepts `TEMPLE_WEB_API_TOKEN` (the bot service key) in addition to user `tera_*` tokens
- Discord bot can query GraphQL directly without the proxy pattern — same auth it uses for all other `/api/discord/*` endpoints
- User tokens still work as before; `requireUser` passes through for either credential
- No auth (or invalid token) still returns `UNAUTHENTICATED`

## Test plan

- [ ] User `tera_*` token → queries succeed
- [ ] Bot service token → queries succeed
- [ ] No token → `UNAUTHENTICATED`
- [ ] Invalid token → `UNAUTHENTICATED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)