### PR TITLE
feat(api): recipes + crafters query for GraphQL v2

### DIFF
--- a/src/server/api/v2/context.ts
+++ b/src/server/api/v2/context.ts
@@ -4,6 +4,7 @@ import { GraphQLError } from "graphql";
 import { eq } from "drizzle-orm";
 import { db } from "~/server/db";
 import { users } from "~/server/db/schema";
+import { env } from "~/env.js";
 
 export type AuthUser = {
   id: string;
@@ -16,13 +17,18 @@ export type AuthUser = {
 
 export type Context = {
   user: AuthUser | null;
+  isServiceAuth: boolean;
   db: typeof db;
 };
 
-async function resolveUser(request: Request): Promise<AuthUser | null> {
+async function resolveAuth(
+  request: Request,
+): Promise<{ user: AuthUser | null; isServiceAuth: boolean }> {
   const authHeader = request.headers.get("authorization");
   const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7).trim() : null;
-  if (!token) return null;
+  if (!token) return { user: null, isServiceAuth: false };
+
+  if (token === env.TEMPLE_WEB_API_TOKEN) return { user: null, isServiceAuth: true };
 
   const tokenHash = createHash("sha256").update(token).digest("hex");
   const result = await db
@@ -38,17 +44,17 @@ async function resolveUser(request: Request): Promise<AuthUser | null> {
     .where(eq(users.apiToken, tokenHash))
     .limit(1);
 
-  return result[0] ?? null;
+  return { user: result[0] ?? null, isServiceAuth: false };
 }
 
 export async function buildContext({ request }: { request: Request }): Promise<Context> {
-  const user = await resolveUser(request);
-  return { user, db };
+  const { user, isServiceAuth } = await resolveAuth(request);
+  return { user, isServiceAuth, db };
 }
 
-/** Throws UNAUTHENTICATED if no valid token was provided. */
-export function requireUser(ctx: Context): AuthUser {
-  if (!ctx.user) {
+/** Throws UNAUTHENTICATED if no valid token was provided. Passes for both user tokens and bot service token. */
+export function requireUser(ctx: Context): AuthUser | null {
+  if (!ctx.user && !ctx.isServiceAuth) {
     throw new GraphQLError("Not authenticated", {
       extensions: { code: "UNAUTHENTICATED" },
     });

--- a/src/server/api/v2/refs.ts
+++ b/src/server/api/v2/refs.ts
@@ -1,6 +1,6 @@
 // src/server/api/v2/refs.ts
 import { builder } from "./builder";
-import type { characters, raids, raidLogs } from "~/server/db/schema";
+import type { characters, raids, raidLogs, recipes } from "~/server/db/schema";
 import type {
   RaidAttendanceData,
   CharacterStatusData,
@@ -10,8 +10,10 @@ import type {
 type CharacterRow = typeof characters.$inferSelect;
 type RaidRow = typeof raids.$inferSelect;
 type RaidLogRow = typeof raidLogs.$inferSelect;
+type RecipeRow = typeof recipes.$inferSelect;
 
-export type { CharacterRow, RaidRow, RaidLogRow };
+export type { CharacterRow, RaidRow, RaidLogRow, RecipeRow };
+export type RecipeCrafterData = { character: CharacterRow; isActiveRaider: boolean };
 
 export const CharacterRef = builder.objectRef<CharacterRow>("Character");
 export const CharacterFamilyRef = builder.objectRef<{ primaryCharacterId: number }>(
@@ -26,3 +28,5 @@ export const RaidLogAttendeeRef = builder.objectRef<{
 export const RaidAttendanceRef = builder.objectRef<RaidAttendanceData>("RaidAttendance");
 export const CharacterStatusRef = builder.objectRef<CharacterStatusData>("CharacterStatus");
 export const FamilyStatusRef = builder.objectRef<FamilyStatusData>("FamilyStatus");
+export const RecipeRef = builder.objectRef<RecipeRow>("Recipe");
+export const RecipeCrafterRef = builder.objectRef<RecipeCrafterData>("RecipeCrafter");

--- a/src/server/api/v2/schema.ts
+++ b/src/server/api/v2/schema.ts
@@ -1,6 +1,6 @@
 // src/server/api/v2/schema.ts
-import { and, desc, eq, gt, gte, ilike, inArray, lte } from "drizzle-orm";
-import { accounts, characters, raids, users } from "~/server/db/schema";
+import { and, asc, desc, eq, gt, gte, ilike, inArray, lte } from "drizzle-orm";
+import { accounts, characters, raids, recipes, users } from "~/server/db/schema";
 import { builder } from "./builder";
 import { requireUser } from "./context";
 
@@ -10,11 +10,18 @@ import "./types/attendance";
 import "./types/raid";
 import "./types/character";
 import "./types/character-family";
+import "./types/recipe";
 
 // User type defines and exports UserRef directly (not via refs.ts)
 import { UserRef, type UserData } from "./types/user";
-import { CharacterRef, CharacterFamilyRef, RaidRef } from "./refs";
-import { CharacterTypeEnum, RaidZoneEnum, GQL_ZONE_TO_DB } from "./types/enums";
+import { CharacterRef, CharacterFamilyRef, RaidRef, RecipeRef } from "./refs";
+import {
+  CharacterTypeEnum,
+  RaidZoneEnum,
+  GQL_ZONE_TO_DB,
+  ProfessionEnum,
+  GQL_PROFESSION_TO_DB,
+} from "./types/enums";
 
 builder.queryType({
   fields: (t) => ({
@@ -138,6 +145,42 @@ builder.queryType({
           .orderBy(desc(raids.date))
           .limit(args.limit ?? 50)
           .offset(args.offset ?? 0);
+      },
+    }),
+
+    /** List recipes with optional profession filter and name search */
+    recipes: t.field({
+      type: [RecipeRef],
+      args: {
+        profession: t.arg({ type: ProfessionEnum, required: false }),
+        search: t.arg.string({ required: false }),
+      },
+      resolve: async (_root, args, ctx) => {
+        requireUser(ctx);
+        const conditions = [];
+        if (args.profession) {
+          const dbProfession = GQL_PROFESSION_TO_DB[args.profession];
+          if (dbProfession)
+            conditions.push(
+              eq(
+                recipes.profession,
+                dbProfession as
+                  | "Alchemy"
+                  | "Blacksmithing"
+                  | "Enchanting"
+                  | "Engineering"
+                  | "Tailoring"
+                  | "Leatherworking"
+                  | "Cooking",
+              ),
+            );
+        }
+        if (args.search) conditions.push(ilike(recipes.recipe, `%${args.search}%`));
+        return ctx.db
+          .select()
+          .from(recipes)
+          .where(conditions.length > 0 ? and(...conditions) : undefined)
+          .orderBy(asc(recipes.profession), asc(recipes.recipe));
       },
     }),
   }),

--- a/src/server/api/v2/types/enums.ts
+++ b/src/server/api/v2/types/enums.ts
@@ -43,3 +43,33 @@ export const DB_ZONE_TO_GQL: Record<string, string> = Object.fromEntries(
 
 /** All GQL zone enum values, used when no zone filter is specified */
 export const ALL_GQL_ZONES = Object.keys(GQL_ZONE_TO_DB);
+
+const PROFESSION_VALUES = [
+  "ALCHEMY",
+  "BLACKSMITHING",
+  "ENCHANTING",
+  "ENGINEERING",
+  "LEATHERWORKING",
+  "TAILORING",
+  "COOKING",
+] as const;
+
+export type ProfessionValues = (typeof PROFESSION_VALUES)[number];
+
+export const ProfessionEnum = builder.enumType("Profession", {
+  values: PROFESSION_VALUES,
+});
+
+export const GQL_PROFESSION_TO_DB: Record<string, string> = {
+  ALCHEMY: "Alchemy",
+  BLACKSMITHING: "Blacksmithing",
+  ENCHANTING: "Enchanting",
+  ENGINEERING: "Engineering",
+  LEATHERWORKING: "Leatherworking",
+  TAILORING: "Tailoring",
+  COOKING: "Cooking",
+};
+
+export const DB_PROFESSION_TO_GQL: Record<string, string> = Object.fromEntries(
+  Object.entries(GQL_PROFESSION_TO_DB).map(([gql, db]) => [db, gql]),
+);

--- a/src/server/api/v2/types/recipe.ts
+++ b/src/server/api/v2/types/recipe.ts
@@ -1,0 +1,71 @@
+// src/server/api/v2/types/recipe.ts
+import { eq } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
+import {
+  characters,
+  characterRecipeMap,
+  primaryRaidAttendanceL6LockoutWk,
+} from "~/server/db/schema";
+import { RecipeRef, RecipeCrafterRef, CharacterRef } from "../refs";
+import { ProfessionEnum, DB_PROFESSION_TO_GQL, type ProfessionValues } from "./enums";
+import { requireUser } from "../context";
+
+RecipeRef.implement({
+  fields: (t) => ({
+    spellId: t.exposeInt("recipeSpellId"),
+    itemId: t.exposeInt("itemId", { nullable: true }),
+    name: t.exposeString("recipe"),
+    isCommon: t.exposeBoolean("isCommon"),
+    notes: t.exposeString("notes", { nullable: true }),
+    tags: t.field({
+      type: ["String"],
+      resolve: (r) => r.tags ?? [],
+    }),
+    profession: t.field({
+      type: ProfessionEnum,
+      resolve: (r) => (DB_PROFESSION_TO_GQL[r.profession] ?? "ALCHEMY") as ProfessionValues,
+    }),
+    crafters: t.field({
+      type: [RecipeCrafterRef],
+      args: {
+        includeInactive: t.arg.boolean({ required: false }),
+      },
+      resolve: async (recipe, args, ctx) => {
+        requireUser(ctx);
+        const primaryChar = alias(characters, "primary_char");
+
+        const [crafterRows, activeRows] = await Promise.all([
+          ctx.db
+            .select({ character: characters, primaryIsIgnored: primaryChar.isIgnored })
+            .from(characterRecipeMap)
+            .innerJoin(characters, eq(characterRecipeMap.characterId, characters.characterId))
+            .leftJoin(primaryChar, eq(characters.primaryCharacterId, primaryChar.characterId))
+            .where(eq(characterRecipeMap.recipeSpellId, recipe.recipeSpellId)),
+          ctx.db
+            .select({ characterId: primaryRaidAttendanceL6LockoutWk.characterId })
+            .from(primaryRaidAttendanceL6LockoutWk),
+        ]);
+
+        const activeIds = new Set(activeRows.map((r) => r.characterId));
+
+        return crafterRows
+          .filter((r) => !r.character.isIgnored && r.primaryIsIgnored !== true)
+          .map((r) => ({
+            character: r.character,
+            isActiveRaider: activeIds.has(
+              r.character.primaryCharacterId ?? r.character.characterId,
+            ),
+          }))
+          .filter((r) => args.includeInactive === true || r.isActiveRaider)
+          .sort((a, b) => (a.character.name ?? "").localeCompare(b.character.name ?? ""));
+      },
+    }),
+  }),
+});
+
+RecipeCrafterRef.implement({
+  fields: (t) => ({
+    character: t.field({ type: CharacterRef, resolve: (r) => r.character }),
+    isActiveRaider: t.exposeBoolean("isActiveRaider"),
+  }),
+});


### PR DESCRIPTION
## Summary

- Adds `recipes(profession, search)` root query to the v2 GraphQL API — returns recipes with optional profession filter and name search
- Adds `Recipe.crafters(includeInactive: Boolean)` field — lists characters who know the recipe; defaults to active raiders only, _ignored_ characters always excluded
- Backports bot service token auth (_TEMPLE_WEB_API_TOKEN_) to this branch so the Discord bot can query recipes directly without a user token

## Filtering rules

_isActiveRaider_ = primary character appears in the 6-lockout-week attendance view. Default (`includeInactive` omitted) returns only active raiders; pass `includeInactive: true` to include inactive crafters too.

## Test plan
- [ ] `recipes(profession: ENCHANTING)` returns list with no crafters filter (active only)
- [ ] `recipes(search: "mongoose") { crafters(includeInactive: true) }` returns both active and inactive crafters
- [ ] Bot service token authenticates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)