### PR TITLE
feat(api): event signups endpoint with character matching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -442,6 +442,7 @@ The website provides a versioned public REST API at `/api/v1/`:
 - `DELETE /api/v1/characters/:id/primary` - Unlink character from its primary
 - `PUT /api/v1/characters/:id/secondaries` - Set secondary characters
 - `GET /api/v1/scheduled-raids` - Upcoming Raid Helper events with existing plan annotations
+- `GET /api/v1/scheduled-raids/:eventId/signups` - Signups for a scheduled event with character matching and 6-week attendance (handles recurring events)
 - `GET /api/v1/raid-plans` - List recent raid plans
 - `POST /api/v1/raid-plans` - Create raid plan
 - `GET /api/v1/raid-plans/:id` - Plan detail (`?include=encounters,encounterGroups,encounterAssignments,aaSlots`)

--- a/src/app/api/v1/scheduled-raids/[eventId]/signups/route.ts
+++ b/src/app/api/v1/scheduled-raids/[eventId]/signups/route.ts
@@ -1,0 +1,233 @@
+import { NextResponse } from "next/server";
+import { inArray } from "drizzle-orm";
+import { logger } from "~/lib/logger";
+import { validateApiToken } from "~/server/api/v1-auth";
+import { matchSignupsToCharacters } from "~/server/api/helpers/match-signups";
+import { env } from "~/env";
+import { db } from "~/server/db";
+import {
+  trackedRaidsL6LockoutWk,
+  primaryRaidAttendeeAndBenchMap,
+  primaryRaidAttendanceL6LockoutWk,
+} from "~/server/db/schema";
+
+const RAID_HELPER_API_BASE = "https://raid-helper.xyz/api";
+
+interface RaidHelperSignup {
+  userId: string;
+  name: string;
+  className: string;
+  specName: string;
+  roleName: string;
+  status: string;
+}
+
+interface RaidHelperEventResponse {
+  id: string;
+  startTime: number;
+  signUps?: RaidHelperSignup[];
+  lastEventId?: string;
+}
+
+export async function GET(request: Request, { params }: { params: Promise<{ eventId: string }> }) {
+  try {
+    const authResult = await validateApiToken(request);
+    if ("error" in authResult) return authResult.error;
+    const { user } = authResult;
+
+    if (!user.isRaidManager) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { eventId } = await params;
+    if (!eventId || eventId.includes("/") || eventId.length > 64) {
+      return NextResponse.json({ error: "Invalid event ID" }, { status: 400 });
+    }
+
+    // 1. Fetch event from Raid Helper, resolve recurring events via lastEventId
+    const initialRes = await fetch(`${RAID_HELPER_API_BASE}/v4/events/${eventId}`, {
+      headers: { Authorization: env.RAID_HELPER_API_KEY },
+    });
+
+    if (initialRes.status === 404) {
+      return NextResponse.json({ error: "Event not found" }, { status: 404 });
+    }
+    if (!initialRes.ok) {
+      return NextResponse.json({ error: "Raid Helper API unavailable" }, { status: 502 });
+    }
+
+    const initialData = (await initialRes.json()) as Record<string, unknown>;
+
+    const actualEventId =
+      !initialData.signUps && initialData.lastEventId
+        ? (initialData.lastEventId as string)
+        : eventId;
+
+    let eventData: RaidHelperEventResponse;
+    if (actualEventId !== eventId) {
+      const resolvedRes = await fetch(`${RAID_HELPER_API_BASE}/v4/events/${actualEventId}`, {
+        headers: { Authorization: env.RAID_HELPER_API_KEY },
+      });
+      if (!resolvedRes.ok) {
+        return NextResponse.json({ error: "Raid Helper API unavailable" }, { status: 502 });
+      }
+      eventData = (await resolvedRes.json()) as RaidHelperEventResponse;
+    } else {
+      eventData = initialData as unknown as RaidHelperEventResponse;
+    }
+
+    const rawSignups: RaidHelperSignup[] = eventData.signUps ?? [];
+
+    // 2. Match signups to DB characters
+    const matchResults = await matchSignupsToCharacters(
+      db,
+      rawSignups.map((s) => ({
+        userId: s.userId,
+        discordName: s.name,
+        className: s.className,
+        specName: s.specName,
+        partyId: null,
+        slotId: null,
+      })),
+    );
+
+    // 3. Collect primary character IDs for batch attendance fetch
+    const primaryIdSet = new Set<number>();
+    for (const result of matchResults) {
+      const primaryId =
+        result.matchedCharacter !== undefined
+          ? (result.matchedCharacter.primaryCharacterId ?? result.matchedCharacter.characterId)
+          : (result.matchedPrimaryCharacterId ?? null);
+      if (primaryId !== null && primaryId !== undefined) {
+        primaryIdSet.add(primaryId);
+      }
+    }
+    const primaryIdList = [...primaryIdSet];
+
+    // 4. Batch attendance — 3 parallel queries regardless of signup count
+    const [allL6Raids, summaryRows, attendanceRows] = await Promise.all([
+      db
+        .select({
+          raidId: trackedRaidsL6LockoutWk.raidId,
+          name: trackedRaidsL6LockoutWk.name,
+          date: trackedRaidsL6LockoutWk.date,
+          zone: trackedRaidsL6LockoutWk.zone,
+          attendanceWeight: trackedRaidsL6LockoutWk.attendanceWeight,
+        })
+        .from(trackedRaidsL6LockoutWk)
+        .orderBy(trackedRaidsL6LockoutWk.date),
+      primaryIdList.length === 0
+        ? Promise.resolve([])
+        : db
+            .select({
+              characterId: primaryRaidAttendanceL6LockoutWk.characterId,
+              weightedAttendancePct: primaryRaidAttendanceL6LockoutWk.weightedAttendancePct,
+              weightedRaidTotal: primaryRaidAttendanceL6LockoutWk.weightedRaidTotal,
+            })
+            .from(primaryRaidAttendanceL6LockoutWk)
+            .where(inArray(primaryRaidAttendanceL6LockoutWk.characterId, primaryIdList)),
+      primaryIdList.length === 0
+        ? Promise.resolve([])
+        : db
+            .select({
+              raidId: primaryRaidAttendeeAndBenchMap.raidId,
+              primaryCharacterId: primaryRaidAttendeeAndBenchMap.primaryCharacterId,
+              attendeeOrBench: primaryRaidAttendeeAndBenchMap.attendeeOrBench,
+            })
+            .from(primaryRaidAttendeeAndBenchMap)
+            .where(inArray(primaryRaidAttendeeAndBenchMap.primaryCharacterId, primaryIdList)),
+    ]);
+
+    // 5. Build lookup maps for in-memory join
+    const summaryMap = new Map(summaryRows.map((r) => [r.characterId, r]));
+
+    const characterRaidStatus = new Map<number, Map<number, string | null>>();
+    for (const row of attendanceRows) {
+      if (row.primaryCharacterId === null || row.raidId === null) continue;
+      if (!characterRaidStatus.has(row.primaryCharacterId)) {
+        characterRaidStatus.set(row.primaryCharacterId, new Map());
+      }
+      characterRaidStatus.get(row.primaryCharacterId)!.set(row.raidId, row.attendeeOrBench);
+    }
+
+    function buildAttendance(primaryId: number) {
+      const summary = summaryMap.get(primaryId);
+      const statusMap = characterRaidStatus.get(primaryId) ?? new Map<number, string | null>();
+      return {
+        attendancePct: summary?.weightedAttendancePct ?? 0,
+        weeksTracked: summary?.weightedRaidTotal ?? 0,
+        raids: allL6Raids.map((raid) => ({
+          raidId: raid.raidId,
+          name: raid.name,
+          date: raid.date,
+          zone: raid.zone,
+          attendanceWeight: raid.attendanceWeight,
+          attendeeOrBench: (statusMap.get(raid.raidId!) ?? null) as "attendee" | "bench" | null,
+        })),
+      };
+    }
+
+    // 6. Assemble response
+    const rawSignupMap = new Map(rawSignups.map((s) => [s.userId, s]));
+
+    const signups = matchResults.map((result) => {
+      const raw = rawSignupMap.get(result.userId);
+
+      const effectivePrimaryId =
+        result.matchedCharacter !== undefined
+          ? (result.matchedCharacter.primaryCharacterId ?? result.matchedCharacter.characterId)
+          : (result.matchedPrimaryCharacterId ?? null);
+
+      let character: {
+        id: number | null;
+        name: string | null;
+        class: string | null;
+        primaryCharacterId: number | null;
+        attendance: ReturnType<typeof buildAttendance>;
+      } | null = null;
+
+      if (result.matchedCharacter !== undefined) {
+        character = {
+          id: result.matchedCharacter.characterId,
+          name: result.matchedCharacter.characterName,
+          class: result.matchedCharacter.characterClass,
+          primaryCharacterId: result.matchedCharacter.primaryCharacterId,
+          attendance: buildAttendance(effectivePrimaryId!),
+        };
+      } else if (effectivePrimaryId !== null) {
+        // Ambiguous match — include family attendance with best-guess primary info
+        character = {
+          id: null,
+          name: result.matchedPrimaryCharacterName ?? null,
+          class: null,
+          primaryCharacterId: effectivePrimaryId,
+          attendance: buildAttendance(effectivePrimaryId),
+        };
+      }
+
+      return {
+        userId: result.userId,
+        discordName: result.discordName,
+        className: result.className,
+        specName: result.specName,
+        roleName: raw?.roleName ?? "",
+        status: raw?.status ?? "",
+        matchStatus: result.status,
+        matchConfidence: result.confidence ?? null,
+        character,
+      };
+    });
+
+    return NextResponse.json({
+      event: {
+        id: eventId,
+        resolvedId: actualEventId,
+        startTime: eventData.startTime,
+      },
+      signups,
+    });
+  } catch (error) {
+    logger.error({ err: error }, "v1 API error");
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/v1/scheduled-raids/[eventId]/signups/route.ts
+++ b/src/app/api/v1/scheduled-raids/[eventId]/signups/route.ts
@@ -1,15 +1,9 @@
 import { NextResponse } from "next/server";
-import { inArray } from "drizzle-orm";
 import { logger } from "~/lib/logger";
 import { validateApiToken } from "~/server/api/v1-auth";
 import { matchSignupsToCharacters } from "~/server/api/helpers/match-signups";
 import { env } from "~/env";
 import { db } from "~/server/db";
-import {
-  trackedRaidsL6LockoutWk,
-  primaryRaidAttendeeAndBenchMap,
-  primaryRaidAttendanceL6LockoutWk,
-} from "~/server/db/schema";
 
 const RAID_HELPER_API_BASE = "https://raid-helper.xyz/api";
 
@@ -91,119 +85,31 @@ export async function GET(request: Request, { params }: { params: Promise<{ even
       })),
     );
 
-    // 3. Collect primary character IDs for batch attendance fetch
-    const primaryIdSet = new Set<number>();
-    for (const result of matchResults) {
-      const primaryId =
-        result.matchedCharacter !== undefined
-          ? (result.matchedCharacter.primaryCharacterId ?? result.matchedCharacter.characterId)
-          : (result.matchedPrimaryCharacterId ?? null);
-      if (primaryId !== null && primaryId !== undefined) {
-        primaryIdSet.add(primaryId);
-      }
-    }
-    const primaryIdList = [...primaryIdSet];
-
-    // 4. Batch attendance — 3 parallel queries regardless of signup count
-    const [allL6Raids, summaryRows, attendanceRows] = await Promise.all([
-      db
-        .select({
-          raidId: trackedRaidsL6LockoutWk.raidId,
-          name: trackedRaidsL6LockoutWk.name,
-          date: trackedRaidsL6LockoutWk.date,
-          zone: trackedRaidsL6LockoutWk.zone,
-          attendanceWeight: trackedRaidsL6LockoutWk.attendanceWeight,
-        })
-        .from(trackedRaidsL6LockoutWk)
-        .orderBy(trackedRaidsL6LockoutWk.date),
-      primaryIdList.length === 0
-        ? Promise.resolve([])
-        : db
-            .select({
-              characterId: primaryRaidAttendanceL6LockoutWk.characterId,
-              weightedAttendancePct: primaryRaidAttendanceL6LockoutWk.weightedAttendancePct,
-              weightedRaidTotal: primaryRaidAttendanceL6LockoutWk.weightedRaidTotal,
-            })
-            .from(primaryRaidAttendanceL6LockoutWk)
-            .where(inArray(primaryRaidAttendanceL6LockoutWk.characterId, primaryIdList)),
-      primaryIdList.length === 0
-        ? Promise.resolve([])
-        : db
-            .select({
-              raidId: primaryRaidAttendeeAndBenchMap.raidId,
-              primaryCharacterId: primaryRaidAttendeeAndBenchMap.primaryCharacterId,
-              attendeeOrBench: primaryRaidAttendeeAndBenchMap.attendeeOrBench,
-            })
-            .from(primaryRaidAttendeeAndBenchMap)
-            .where(inArray(primaryRaidAttendeeAndBenchMap.primaryCharacterId, primaryIdList)),
-    ]);
-
-    // 5. Build lookup maps for in-memory join
-    const summaryMap = new Map(summaryRows.map((r) => [r.characterId, r]));
-
-    const characterRaidStatus = new Map<number, Map<number, string | null>>();
-    for (const row of attendanceRows) {
-      if (row.primaryCharacterId === null || row.raidId === null) continue;
-      if (!characterRaidStatus.has(row.primaryCharacterId)) {
-        characterRaidStatus.set(row.primaryCharacterId, new Map());
-      }
-      characterRaidStatus.get(row.primaryCharacterId)!.set(row.raidId, row.attendeeOrBench);
-    }
-
-    function buildAttendance(primaryId: number) {
-      const summary = summaryMap.get(primaryId);
-      const statusMap = characterRaidStatus.get(primaryId) ?? new Map<number, string | null>();
-      return {
-        attendancePct: summary?.weightedAttendancePct ?? 0,
-        weeksTracked: summary?.weightedRaidTotal ?? 0,
-        raids: allL6Raids.map((raid) => ({
-          raidId: raid.raidId,
-          name: raid.name,
-          date: raid.date,
-          zone: raid.zone,
-          attendanceWeight: raid.attendanceWeight,
-          attendeeOrBench: (statusMap.get(raid.raidId!) ?? null) as "attendee" | "bench" | null,
-        })),
-      };
-    }
-
-    // 6. Assemble response
+    // 3. Assemble response — character identity only, no attendance
+    //    Callers wanting ghost-likelihood should cross-reference past event signups
+    //    via GET /api/v1/scheduled-raids/:pastEventId/signups, then check attendance
+    //    per-character via GET /api/v1/characters/:id/attendance for the intersection.
     const rawSignupMap = new Map(rawSignups.map((s) => [s.userId, s]));
 
     const signups = matchResults.map((result) => {
       const raw = rawSignupMap.get(result.userId);
 
-      const effectivePrimaryId =
+      const character =
         result.matchedCharacter !== undefined
-          ? (result.matchedCharacter.primaryCharacterId ?? result.matchedCharacter.characterId)
-          : (result.matchedPrimaryCharacterId ?? null);
-
-      let character: {
-        id: number | null;
-        name: string | null;
-        class: string | null;
-        primaryCharacterId: number | null;
-        attendance: ReturnType<typeof buildAttendance>;
-      } | null = null;
-
-      if (result.matchedCharacter !== undefined) {
-        character = {
-          id: result.matchedCharacter.characterId,
-          name: result.matchedCharacter.characterName,
-          class: result.matchedCharacter.characterClass,
-          primaryCharacterId: result.matchedCharacter.primaryCharacterId,
-          attendance: buildAttendance(effectivePrimaryId!),
-        };
-      } else if (effectivePrimaryId !== null) {
-        // Ambiguous match — include family attendance with best-guess primary info
-        character = {
-          id: null,
-          name: result.matchedPrimaryCharacterName ?? null,
-          class: null,
-          primaryCharacterId: effectivePrimaryId,
-          attendance: buildAttendance(effectivePrimaryId),
-        };
-      }
+          ? {
+              id: result.matchedCharacter.characterId,
+              name: result.matchedCharacter.characterName,
+              class: result.matchedCharacter.characterClass,
+              primaryCharacterId: result.matchedCharacter.primaryCharacterId,
+            }
+          : result.matchedPrimaryCharacterId != null
+            ? {
+                id: null,
+                name: result.matchedPrimaryCharacterName ?? null,
+                class: null,
+                primaryCharacterId: result.matchedPrimaryCharacterId,
+              }
+            : null;
 
       return {
         userId: result.userId,

--- a/src/lib/openapi-registry.ts
+++ b/src/lib/openapi-registry.ts
@@ -542,11 +542,6 @@ export const EventSignupCharacterSchema = registry.register(
       description: "null for ambiguous matches",
     }),
     primaryCharacterId: z.number().nullable().openapi({ example: null }),
-    attendance: z.object({
-      attendancePct: z.number().openapi({ example: 0.83 }),
-      weeksTracked: z.number().openapi({ example: 6 }),
-      raids: z.array(AttendanceRaidSchema),
-    }),
   }),
 );
 

--- a/src/lib/openapi-registry.ts
+++ b/src/lib/openapi-registry.ts
@@ -528,6 +528,95 @@ registry.registerPath({
   },
 });
 
+export const EventSignupCharacterSchema = registry.register(
+  "EventSignupCharacter",
+  z.object({
+    id: z.number().nullable().openapi({
+      example: 12345,
+      description:
+        "Character ID. null for ambiguous matches where the exact character is uncertain.",
+    }),
+    name: z.string().nullable().openapi({ example: "Khlav" }),
+    class: z.string().nullable().openapi({
+      example: "Warrior",
+      description: "null for ambiguous matches",
+    }),
+    primaryCharacterId: z.number().nullable().openapi({ example: null }),
+    attendance: z.object({
+      attendancePct: z.number().openapi({ example: 0.83 }),
+      weeksTracked: z.number().openapi({ example: 6 }),
+      raids: z.array(AttendanceRaidSchema),
+    }),
+  }),
+);
+
+export const EventSignupSchema = registry.register(
+  "EventSignup",
+  z.object({
+    userId: z.string().openapi({ example: "123456789012345678" }),
+    discordName: z.string().openapi({ example: "Khlav" }),
+    className: z.string().openapi({ example: "Warrior" }),
+    specName: z.string().openapi({ example: "Arms" }),
+    roleName: z.string().openapi({ example: "Melee" }),
+    status: z.string().openapi({
+      example: "Confirmed",
+      description: "Raid Helper signup status: Confirmed, Bench, Tentative, Late, Absence, Absent",
+    }),
+    matchStatus: z.enum(["matched", "ambiguous", "unmatched", "skipped"]).openapi({
+      example: "matched",
+      description:
+        "matched: linked to a DB character. ambiguous: best-guess family found. unmatched: no match. skipped: non-WoW-class signup (Bench, Absent, etc).",
+    }),
+    matchConfidence: z.number().nullable().openapi({ example: 0.99 }),
+    character: EventSignupCharacterSchema.nullable().openapi({ example: null }),
+  }),
+);
+
+export const EventSignupsResponseSchema = registry.register(
+  "EventSignupsResponse",
+  z.object({
+    event: z.object({
+      id: z.string().openapi({ example: "1234567890" }),
+      resolvedId: z.string().openapi({
+        example: "1234567891",
+        description:
+          "Actual event instance ID after recurring-event resolution. Equal to id when not a recurring event.",
+      }),
+      startTime: z.number().openapi({ example: 1747180800 }),
+    }),
+    signups: z.array(EventSignupSchema),
+  }),
+);
+
+registry.registerPath({
+  method: "get",
+  path: "/api/v1/scheduled-raids/{eventId}/signups",
+  operationId: "getEventSignups",
+  tags: ["Scheduled Raids"],
+  summary: "Get signups for a scheduled event",
+  description:
+    "Fetches Raid Helper signups for a given event, matches each to a DB character, and inlines 6-week attendance. Returns all signups regardless of status — use matchStatus to filter. Handles recurring events automatically. Requires isRaidManager.",
+  security: [{ BearerToken: [] }],
+  request: {
+    params: z.object({
+      eventId: z.string().openapi({ example: "1234567890" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Event signups with character matching and attendance",
+      content: {
+        "application/json": { schema: EventSignupsResponseSchema },
+      },
+    },
+    400: { description: "Invalid event ID format" },
+    401: { description: "Invalid or missing API token" },
+    403: { description: "Not a raid manager" },
+    404: { description: "Event not found in Raid Helper" },
+    502: { description: "Raid Helper API unavailable" },
+  },
+});
+
 registry.registerPath({
   method: "get",
   path: "/api/v1/scheduled-raids",

--- a/src/server/api/helpers/match-signups.ts
+++ b/src/server/api/helpers/match-signups.ts
@@ -464,6 +464,25 @@ export async function matchSignupsToCharacters(
     const secondFamily = rankedFamilies[1];
 
     if (secondFamily && topFamily.score - secondFamily.score < 25 && topFamily.score < 150) {
+      // Before declaring ambiguous, check if class breaks the tie
+      const tiedFamilies = rankedFamilies.filter((f) => topFamily.score - f.score < 25);
+      const classMatchingFamilies = tiedFamilies.filter(
+        (entry) =>
+          chooseFamilyCharacterByClass(familyMap.get(entry.familyId) ?? [], signup.resolvedClass)
+            .type === "matched",
+      );
+      if (classMatchingFamilies.length === 1) {
+        results.push(
+          resolveFamily(
+            classMatchingFamilies[0]!.familyId,
+            classMatchingFamilies[0]!.source,
+            classMatchingFamilies[0]!.score / 200,
+            "Class match broke the tie between equally-scored families.",
+          ),
+        );
+        continue;
+      }
+
       const topCandidates = rankedFamilies.slice(0, 4).flatMap((entry) => {
         const family = familyMap.get(entry.familyId) ?? [];
         const primaryCharacter = allCharactersById.get(entry.familyId);


### PR DESCRIPTION
Adds _GET /api/v1/scheduled-raids/:eventId/signups_ so Templar can fetch who signed up for a Raid Helper event and match them to guild characters — without requiring a raid plan to exist.

### Features + updates

- New endpoint returns all signups matched to DB characters using the same logic as the raid plan sync flow
- Each signup includes _matchStatus_ (matched/ambiguous/unmatched/skipped), _matchConfidence_, and character identity (_id_, _name_, _class_, _primaryCharacterId_)
- Handles recurring/scheduled events automatically by resolving _lastEventId_
- Returns all signup statuses (Confirmed, Bench, Absent, etc.) so Templar can filter as needed

### Fixes

- Cross-family name-token tiebreaker now uses signup class to break ties — previously, a signup matching two families at equal score could be marked ambiguous even when only one family contained a character of the matching class

### Technical details

- Reuses _matchSignupsToCharacters_ helper shared with the UI tRPC flow and REST sync-signups endpoint
- Within-family same-class ambiguity (e.g. two Shamans in one family) correctly remains _ambiguous_; _primaryCharacterId_ is still returned so attendance rolls up correctly regardless