### PR TITLE
fix(characters): show excluded state instead of 0% for ignored characters

### DIFF
--- a/src/app/api/v1/characters/[id]/attendance/route.ts
+++ b/src/app/api/v1/characters/[id]/attendance/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
     let primaryCharacterId = characterId;
     const char = await db.query.characters.findFirst({
       where: eq(characters.characterId, characterId),
-      columns: { primaryCharacterId: true, name: true, isPrimary: true },
+      columns: { primaryCharacterId: true, name: true, isPrimary: true, isIgnored: true },
     });
 
     if (!char) {
@@ -72,6 +72,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
     return NextResponse.json({
       characterId,
       characterName: char.name,
+      isIgnored: char.isIgnored ?? false,
       attendancePct,
       weeksTracked,
       raids: attendanceReport.map((r) => ({

--- a/src/components/characters/character-detail.tsx
+++ b/src/components/characters/character-detail.tsx
@@ -16,7 +16,13 @@ import { api } from "~/trpc/react";
 import { CharacterBadges } from "~/components/characters/character-badges";
 // import { PrimaryCharacterAttendanceReport } from "~/components/characters/primary-character-attendance-report";
 
-function CharacterAttendanceContent({ characterId }: { characterId: number }) {
+function CharacterAttendanceContent({
+  characterId,
+  isIgnored,
+}: {
+  characterId: number;
+  isIgnored?: boolean;
+}) {
   const { data: attendanceData } = api.character.getPrimaryRaidAttendanceL6LockoutWk.useQuery({
     characterId,
   });
@@ -29,11 +35,17 @@ function CharacterAttendanceContent({ characterId }: { characterId: number }) {
 
   return (
     <>
-      <AttendanceProgressBar
-        attendancePct={attendancePct}
-        weightedAttendance={weightedAttendance}
-        showEligibility={true}
-      />
+      {isIgnored ? (
+        <p className="text-sm text-muted-foreground">
+          Excluded from attendance tracking.
+        </p>
+      ) : (
+        <AttendanceProgressBar
+          attendancePct={attendancePct}
+          weightedAttendance={weightedAttendance}
+          showEligibility={true}
+        />
+      )}
       <AttendanceHeatmapGrid
         characterId={characterId}
         showCreditsRow={true}
@@ -117,7 +129,7 @@ export function CharacterDetail({
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
-                <CharacterAttendanceContent characterId={characterId} />
+                <CharacterAttendanceContent characterId={characterId} isIgnored={characterData.isIgnored} />
               </CardContent>
             </Card>
           </>

--- a/src/components/characters/character-detail.tsx
+++ b/src/components/characters/character-detail.tsx
@@ -36,9 +36,9 @@ function CharacterAttendanceContent({
   return (
     <>
       {isIgnored ? (
-        <p className="text-sm text-muted-foreground">
-          Excluded from attendance tracking.
-        </p>
+        <div className="flex h-10 items-center justify-center rounded-md border border-dashed border-border text-sm text-muted-foreground">
+          Excluded from attendance tracking
+        </div>
       ) : (
         <AttendanceProgressBar
           attendancePct={attendancePct}


### PR DESCRIPTION
Ignored characters are excluded from the attendance view, causing the progress bar to display 0% misleadingly. Now shows "Excluded from attendance tracking" text in the widget, and the v1 API attendance endpoint includes an `isIgnored` field so consumers can distinguish exclusion from genuine zero attendance.

Closes #252

https://claude.ai/code/session_01578ZWkZBCfwKSYRZMjQ897