### PR TITLE
Fix attendance widget showing 0% for ignored characters

### DIFF
--- a/src/app/api/v1/characters/[id]/attendance/route.ts
+++ b/src/app/api/v1/characters/[id]/attendance/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
     let primaryCharacterId = characterId;
     const char = await db.query.characters.findFirst({
       where: eq(characters.characterId, characterId),
-      columns: { primaryCharacterId: true, name: true, isPrimary: true },
+      columns: { primaryCharacterId: true, name: true, isPrimary: true, isIgnored: true },
     });
 
     if (!char) {
@@ -72,6 +72,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
     return NextResponse.json({
       characterId,
       characterName: char.name,
+      isIgnored: char.isIgnored ?? false,
       attendancePct,
       weeksTracked,
       raids: attendanceReport.map((r) => ({

--- a/src/components/characters/character-detail.tsx
+++ b/src/components/characters/character-detail.tsx
@@ -16,7 +16,13 @@ import { api } from "~/trpc/react";
 import { CharacterBadges } from "~/components/characters/character-badges";
 // import { PrimaryCharacterAttendanceReport } from "~/components/characters/primary-character-attendance-report";
 
-function CharacterAttendanceContent({ characterId }: { characterId: number }) {
+function CharacterAttendanceContent({
+  characterId,
+  isIgnored,
+}: {
+  characterId: number;
+  isIgnored?: boolean;
+}) {
   const { data: attendanceData } = api.character.getPrimaryRaidAttendanceL6LockoutWk.useQuery({
     characterId,
   });
@@ -29,11 +35,17 @@ function CharacterAttendanceContent({ characterId }: { characterId: number }) {
 
   return (
     <>
-      <AttendanceProgressBar
-        attendancePct={attendancePct}
-        weightedAttendance={weightedAttendance}
-        showEligibility={true}
-      />
+      {isIgnored ? (
+        <p className="text-sm text-muted-foreground">
+          Excluded from attendance tracking.
+        </p>
+      ) : (
+        <AttendanceProgressBar
+          attendancePct={attendancePct}
+          weightedAttendance={weightedAttendance}
+          showEligibility={true}
+        />
+      )}
       <AttendanceHeatmapGrid
         characterId={characterId}
         showCreditsRow={true}
@@ -117,7 +129,7 @@ export function CharacterDetail({
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
-                <CharacterAttendanceContent characterId={characterId} />
+                <CharacterAttendanceContent characterId={characterId} isIgnored={characterData.isIgnored} />
               </CardContent>
             </Card>
           </>

--- a/src/components/characters/character-detail.tsx
+++ b/src/components/characters/character-detail.tsx
@@ -36,9 +36,9 @@ function CharacterAttendanceContent({
   return (
     <>
       {isIgnored ? (
-        <p className="text-sm text-muted-foreground">
-          Excluded from attendance tracking.
-        </p>
+        <div className="flex h-10 items-center justify-center rounded-md border border-dashed border-border text-sm text-muted-foreground">
+          Excluded from attendance tracking
+        </div>
       ) : (
         <AttendanceProgressBar
           attendancePct={attendancePct}

--- a/src/components/dashboard/personal-attendance-summary.tsx
+++ b/src/components/dashboard/personal-attendance-summary.tsx
@@ -273,11 +273,17 @@ export function PersonalAttendanceSummary({
       </CardHeader>
       <CardContent className="space-y-4 pt-0">
         {/* Progress Bar */}
-        <AttendanceProgressBar
-          attendancePct={attendancePct}
-          weightedAttendance={userAttendance?.weightedAttendance ?? 0}
-          showEligibility={true}
-        />
+        {characterData?.isIgnored ? (
+          <div className="flex h-10 items-center justify-center rounded-md border border-dashed border-border text-sm text-muted-foreground">
+            Excluded from attendance tracking
+          </div>
+        ) : (
+          <AttendanceProgressBar
+            attendancePct={attendancePct}
+            weightedAttendance={userAttendance?.weightedAttendance ?? 0}
+            showEligibility={true}
+          />
+        )}
 
         {/* Heatmap Grid */}
         {activeCharacterId && (


### PR DESCRIPTION
Ignored characters are excluded from the attendance view, which caused the progress bar to show a misleading 0% instead of reflecting that the character isn't being tracked.

### Fixes

- Character page and dashboard attendance widget now show a "Excluded from attendance tracking" placeholder instead of a 0% progress bar when the character has _isIgnored_ set
- v1 API _/characters/:id/attendance_ response now includes an _isIgnored_ field so API consumers (e.g. Templar bot) can distinguish exclusion from genuine zero attendance

Closes #252

---
_Generated by [Claude Code](https://claude.ai/code/session_01578ZWkZBCfwKSYRZMjQ897)_